### PR TITLE
Refactor: Remove comments and update coding standards

### DIFF
--- a/PRD_TODO.md
+++ b/PRD_TODO.md
@@ -199,6 +199,10 @@ Beyond the core principles above, the following practices are essential for a hi
     *   Consider integration tests for interactions between components.
     *   Testing helps ensure code quality, prevents regressions, and provides confidence when refactoring or adding new features. (Specific testing strategies and coverage targets might be detailed in a separate document if needed).
 
+### 10.5 Self-Explanatory Code
+*   **Principle:** Code should be self-explanatory. If not, there is a design problem. Avoid adding comments.
+*   **Rationale:** Code that requires extensive comments to be understood can indicate overly complex logic, poor naming, or a design that is difficult to follow. Striving for self-documenting code through clear naming, logical structure, and well-defined components makes the codebase easier to understand and maintain directly from the code itself. While comments have their place for explaining *why* something non-obvious is done, the primary goal should be clarity in the code itself.
+
 ---
 # END (Original PRD)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,7 +10,6 @@ import (
 	httpinternal "gandalf-budget/internal/http"
 	"gandalf-budget/internal/store"
 
-	// "github.com/jmoiron/sqlx" // Not directly used here, but db is of this type
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -40,7 +39,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create sub VFS for embedded_web_dist: %v", err)
 	}
-	router := httpinternal.NewRouter(distFS, db) // Pass db connection
+	router := httpinternal.NewRouter(distFS, db)
 
 	log.Println("Starting HTTP server on :8080")
 	if err := http.ListenAndServe(":8080", router); err != nil {

--- a/internal/app/dashboard.go
+++ b/internal/app/dashboard.go
@@ -1,33 +1,29 @@
-// Package app contains the core application logic.
 package app
 
-// DashboardPayload represents the data structure for the dashboard.
 type DashboardPayload struct {
-	MonthID         int               `json:"month_id"`         // The ID of the month.
-	Year            int               `json:"year"`             // The year.
-	Month           string            `json:"month"`            // The name of the month (e.g., "January").
-	TotalExpected   float64           `json:"total_expected"`   // The total expected amount for the month.
-	TotalActual     float64           `json:"total_actual"`     // The total actual amount for the month.
-	TotalDifference float64           `json:"total_difference"` // The difference between total expected and total actual.
-	CategorySummaries []CategorySummary `json:"category_summaries"` // A slice of category summaries.
+	MonthID         int               `json:"month_id"`
+	Year            int               `json:"year"`
+	Month           string            `json:"month"`
+	TotalExpected   float64           `json:"total_expected"`
+	TotalActual     float64           `json:"total_actual"`
+	TotalDifference float64           `json:"total_difference"`
+	CategorySummaries []CategorySummary `json:"category_summaries"`
 }
 
-// CategorySummary represents the summary of a specific category.
 type CategorySummary struct {
-	CategoryID    int                `json:"category_id"`    // The ID of the category.
-	CategoryName  string             `json:"category_name"`  // The name of the category.
-	CategoryColor string             `json:"category_color"` // The color associated with the category.
-	TotalExpected float64            `json:"total_expected"` // The total expected amount for this category.
-	TotalActual   float64            `json:"total_actual"`   // The total actual amount for this category.
-	Difference    float64            `json:"difference"`     // The difference between expected and actual for this category.
-	BudgetLines   []BudgetLineDetail `json:"budget_lines"`   // A slice of budget line details for this category.
+	CategoryID    int                `json:"category_id"`
+	CategoryName  string             `json:"category_name"`
+	CategoryColor string             `json:"category_color"`
+	TotalExpected float64            `json:"total_expected"`
+	TotalActual   float64            `json:"total_actual"`
+	Difference    float64            `json:"difference"`
+	BudgetLines   []BudgetLineDetail `json:"budget_lines"`
 }
 
-// BudgetLineDetail represents the details of a specific budget line item.
 type BudgetLineDetail struct {
-	BudgetLineID   int     `json:"budget_line_id"`   // The ID of the budget line.
-	Label          string  `json:"label"`            // The label or name of the budget line item.
-	ExpectedAmount float64 `json:"expected_amount"`  // The expected amount for this budget line item.
-	ActualAmount   float64 `json:"actual_amount"`    // The actual amount for this budget line item.
-	Difference     float64 `json:"difference"`       // The difference between expected and actual for this budget line item.
+	BudgetLineID   int     `json:"budget_line_id"`
+	Label          string  `json:"label"`
+	ExpectedAmount float64 `json:"expected_amount"`
+	ActualAmount   float64 `json:"actual_amount"`
+	Difference     float64 `json:"difference"`
 }

--- a/internal/app/setup.go
+++ b/internal/app/setup.go
@@ -4,35 +4,23 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"strings" // Required for strings.Contains
+	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
 )
 
-// SeedInitialMonth checks if the months table is empty and, if so,
-// seeds it with the current calendar month and year.
 func SeedInitialMonth(db *sqlx.DB) error {
 	log.Println("Checking if initial month seeding is required...")
 	var count int
 	err := db.Get(&count, "SELECT COUNT(*) FROM months")
 	if err != nil {
-		// This might happen if the table doesn't exist yet (e.g., first run before migrations)
-		// Or if there's some other DB error.
-		// If migrations haven't run, this will fail. This function should run AFTER migrations.
 		log.Printf("Could not query count from months table (migrations might not have run yet): %v", err)
-		// Return nil because the migration process should handle table creation.
-		// If migrations did run and this still fails, it's a more serious issue.
-        // For now, assume migrations will create the table. If they did, and count fails, that's an error.
-        // Let's refine: if the error is "no such table", it's fine here. Otherwise, it's an actual error.
         if err != sql.ErrNoRows && !strings.Contains(err.Error(), "no such table") {
              return fmt.Errorf("failed to query count from months table: %w", err)
         }
-        // If "no such table" or ErrNoRows, means table is effectively empty or not yet created by migration.
-        // We'll proceed assuming migration will create it, and then this logic will be fine on next startup.
-        // Or, if it *was* created and is empty, count will be 0.
         log.Println("Months table likely not yet created or empty; proceeding with seeding check logic.")
-        count = 0 // Treat as empty
+        count = 0
 	}
 
 	if count == 0 {

--- a/internal/http/board_handlers.go
+++ b/internal/http/board_handlers.go
@@ -33,8 +33,6 @@ func GetBoardDataHandler(s store.Store) http.HandlerFunc {
 
 		boardData, err := s.GetBoardData(monthID)
 		if err != nil {
-			// Log the error server-side
-			// log.Printf("Error fetching board data: %v", err)
 			http.Error(w, "Failed to fetch board data", http.StatusInternalServerError)
 			return
 		}
@@ -45,8 +43,6 @@ func GetBoardDataHandler(s store.Store) http.HandlerFunc {
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(boardData); err != nil {
-			// Log the error server-side
-			// log.Printf("Error encoding board data to JSON: %v", err)
 			http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		}
 	}

--- a/internal/http/budget_line_handlers.go
+++ b/internal/http/budget_line_handlers.go
@@ -10,9 +10,6 @@ import (
 	"strings" // For TrimSuffix and Split
 )
 
-// CreateBudgetLineHandler handles the creation of a new budget line.
-// It expects a JSON payload with month_id, category_id, label, and expected amount.
-// It creates the budget line and an associated actual line with 0 actual amount.
 func CreateBudgetLineHandler(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -28,7 +25,6 @@ func CreateBudgetLineHandler(s store.Store) http.HandlerFunc {
 		}
 		defer r.Body.Close()
 
-		// Basic validation
 		if bl.MonthID == 0 || bl.CategoryID == 0 || bl.Label == "" {
 			http.Error(w, "Missing required fields: month_id, category_id, label", http.StatusBadRequest)
 			return
@@ -41,8 +37,7 @@ func CreateBudgetLineHandler(s store.Store) http.HandlerFunc {
 			return
 		}
 
-		// Set the ID on the object that was passed in, as it's now populated
-		bl.ID = int(budgetLineID) // Assuming budgetLineID is int64, and bl.ID is int
+		bl.ID = int(budgetLineID)
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -52,9 +47,6 @@ func CreateBudgetLineHandler(s store.Store) http.HandlerFunc {
 	}
 }
 
-// UpdateActualLineHandler handles updates to an existing actual line.
-// It expects the actual line ID in the URL path (e.g., /actual-lines/{id})
-// and a JSON payload with the 'actual' amount.
 func UpdateActualLineHandler(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
@@ -89,7 +81,6 @@ func UpdateActualLineHandler(s store.Store) http.HandlerFunc {
 			return
 		}
 
-		// Fetch existing actual line
 		al, err := s.GetActualLineByID(actualLineID)
 		if err != nil {
 			log.Printf("Error fetching actual line ID %d for update: %v", actualLineID, err)
@@ -117,9 +108,6 @@ func UpdateActualLineHandler(s store.Store) http.HandlerFunc {
 	}
 }
 
-// UpdateBudgetLineHandler handles updates to an existing budget line.
-// It expects the budget line ID in the URL path (e.g., /budget-lines/{id})
-// and a JSON payload with fields to update (label, expected).
 func UpdateBudgetLineHandler(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
@@ -127,9 +115,6 @@ func UpdateBudgetLineHandler(s store.Store) http.HandlerFunc {
 			return
 		}
 
-		// Assuming ID is extracted from path, e.g. using a router like Gorilla Mux.
-		// For standard library, it's more complex. Let's assume ID is the last path segment.
-		// e.g. /api/v1/budget-lines/123
 		pathParts := strings.Split(strings.TrimSuffix(r.URL.Path, "/"), "/")
 		idStr := pathParts[len(pathParts)-1]
 		budgetLineID, err := strconv.ParseInt(idStr, 10, 64)
@@ -149,7 +134,6 @@ func UpdateBudgetLineHandler(s store.Store) http.HandlerFunc {
 		}
 		defer r.Body.Close()
 
-		// Fetch existing budget line
 		bl, err := s.GetBudgetLineByID(budgetLineID)
 		if err != nil {
 			log.Printf("Error fetching budget line ID %d for update: %v", budgetLineID, err)
@@ -161,14 +145,12 @@ func UpdateBudgetLineHandler(s store.Store) http.HandlerFunc {
 			return
 		}
 
-		// Update fields if provided in the request
 		if reqBody.Label != nil {
 			bl.Label = *reqBody.Label
 		}
 		if reqBody.Expected != nil {
 			bl.Expected = *reqBody.Expected
 		}
-		// MonthID and CategoryID are not updatable through this handler for now.
 
 		if err := s.UpdateBudgetLine(bl); err != nil {
 			log.Printf("Error updating budget line ID %d: %v", budgetLineID, err)
@@ -184,8 +166,6 @@ func UpdateBudgetLineHandler(s store.Store) http.HandlerFunc {
 	}
 }
 
-// DeleteBudgetLineHandler handles the deletion of a budget line.
-// It expects the budget line ID in the URL path (e.g., /budget-lines/{id}).
 func DeleteBudgetLineHandler(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
@@ -203,18 +183,15 @@ func DeleteBudgetLineHandler(s store.Store) http.HandlerFunc {
 
 		err = s.DeleteBudgetLine(budgetLineID)
 		if err != nil {
-			// Consider specific error types, e.g., sql.ErrNoRows for not found
 			log.Printf("Error deleting budget line ID %d: %v", budgetLineID, err)
 			http.Error(w, fmt.Sprintf("Failed to delete budget line: %v", err), http.StatusInternalServerError)
 			return
 		}
 
-		w.WriteHeader(http.StatusNoContent) // 204 No Content
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 
-// GetBudgetLinesByMonthIDHandler handles fetching budget lines for a specific month.
-// It expects a 'month_id' query parameter.
 func GetBudgetLinesByMonthIDHandler(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -242,7 +219,7 @@ func GetBudgetLinesByMonthIDHandler(s store.Store) http.HandlerFunc {
 		}
 
 		if budgetLines == nil {
-			budgetLines = []store.BudgetLine{} // Return empty list instead of null
+			budgetLines = []store.BudgetLine{}
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/http/budget_line_handlers_test.go
+++ b/internal/http/budget_line_handlers_test.go
@@ -11,16 +11,13 @@ import (
 	"testing"
 )
 
-// MockStore is a mock implementation of the store.Store interface for testing.
 type MockStore struct {
-	// Category methods
 	MockGetAllCategories func() ([]store.Category, error)
 	MockCreateCategory   func(category *store.Category) error
 	MockGetCategoryByID  func(id int64) (*store.Category, error)
 	MockUpdateCategory   func(category *store.Category) error
 	MockDeleteCategory   func(id int64) error
 
-	// BudgetLine and ActualLine methods
 	MockCreateBudgetLine        func(b *store.BudgetLine) (int64, error)
 	MockGetBudgetLinesByMonthID func(monthID int) ([]store.BudgetLine, error)
 	MockUpdateBudgetLine        func(b *store.BudgetLine) error
@@ -30,7 +27,6 @@ type MockStore struct {
 	MockGetBudgetLineByID       func(id int64) (*store.BudgetLine, error)
 }
 
-// Implement store.Store interface for MockStore
 func (m *MockStore) GetAllCategories() ([]store.Category, error) {
 	if m.MockGetAllCategories != nil {
 		return m.MockGetAllCategories()
@@ -115,10 +111,9 @@ func (m *MockStore) GetBudgetLineByID(id int64) (*store.BudgetLine, error) {
 	return nil, fmt.Errorf("MockGetBudgetLineByID not implemented")
 }
 
-// TestCreateBudgetLineHandler tests the CreateBudgetLineHandler.
 func TestCreateBudgetLineHandler(t *testing.T) {
 	mockStore := &MockStore{}
-	handler := CreateBudgetLineHandler(mockStore) // Assuming this is the correct handler name
+	handler := CreateBudgetLineHandler(mockStore)
 
 	t.Run("successful creation", func(t *testing.T) {
 		expectedID := int64(1)
@@ -129,7 +124,7 @@ func TestCreateBudgetLineHandler(t *testing.T) {
 			Expected:   150.00,
 		}
 		createdBudgetLine := store.BudgetLine{
-			ID:         int(expectedID), // Note: handler sets this
+			ID:         int(expectedID),
 			MonthID:    inputBudgetLine.MonthID,
 			CategoryID: inputBudgetLine.CategoryID,
 			Label:      inputBudgetLine.Label,
@@ -140,7 +135,6 @@ func TestCreateBudgetLineHandler(t *testing.T) {
 			if bl.Label != inputBudgetLine.Label || bl.Expected != inputBudgetLine.Expected || bl.MonthID != inputBudgetLine.MonthID || bl.CategoryID != inputBudgetLine.CategoryID {
 				t.Errorf("MockCreateBudgetLine called with unexpected data: got %+v, want label %s", bl, inputBudgetLine.Label)
 			}
-			// The handler will update the ID of the passed-in budget line, so we don't check it here.
 			return expectedID, nil
 		}
 
@@ -165,7 +159,6 @@ func TestCreateBudgetLineHandler(t *testing.T) {
 		if respBody.Label != createdBudgetLine.Label {
 			t.Errorf("expected label %s, got %s", createdBudgetLine.Label, respBody.Label)
 		}
-		// Add more assertions for other fields if necessary
 	})
 
 	t.Run("invalid request body - bad JSON", func(t *testing.T) {
@@ -178,7 +171,7 @@ func TestCreateBudgetLineHandler(t *testing.T) {
 	})
 
 	t.Run("missing required fields", func(t *testing.T) {
-		budgetLineJSON := `{"label":"Test"}` // Missing month_id, category_id
+		budgetLineJSON := `{"label":"Test"}`
 		req := httptest.NewRequest("POST", "/api/v1/budget-lines", strings.NewReader(budgetLineJSON))
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
@@ -201,7 +194,6 @@ func TestCreateBudgetLineHandler(t *testing.T) {
 	})
 }
 
-// Placeholder for other handler tests
 func TestGetBudgetLinesByMonthIDHandler(t *testing.T) {
 	mockStore := &MockStore{}
 	handler := GetBudgetLinesByMonthIDHandler(mockStore)
@@ -216,7 +208,7 @@ func TestGetBudgetLinesByMonthIDHandler(t *testing.T) {
 		expectedBudgetLines := []store.BudgetLine{
 			{ID: 1, MonthID: monthID, CategoryID: 1, Label: "Food", Expected: 200, ActualID: &actualID1, ActualAmount: &actualAmount1},
 			{ID: 2, MonthID: monthID, CategoryID: 2, Label: "Gas", Expected: 50, ActualID: &actualID2, ActualAmount: &actualAmount2},
-			{ID: 3, MonthID: monthID, CategoryID: 3, Label: "Rent", Expected: 1000, ActualID: nil, ActualAmount: nil}, // Case with no actual line
+			{ID: 3, MonthID: monthID, CategoryID: 3, Label: "Rent", Expected: 1000, ActualID: nil, ActualAmount: nil},
 		}
 		mockStore.MockGetBudgetLinesByMonthID = func(mID int) ([]store.BudgetLine, error) {
 			if mID != monthID {
@@ -246,14 +238,12 @@ func TestGetBudgetLinesByMonthIDHandler(t *testing.T) {
 			if respLine.ID != expectedLine.ID || respLine.Label != expectedLine.Label || respLine.Expected != expectedLine.Expected {
 				t.Errorf("mismatch in line %d basic data: expected %+v, got %+v", i, expectedLine, respLine)
 			}
-			// Compare ActualID
 			if expectedLine.ActualID == nil && respLine.ActualID != nil {
 				t.Errorf("mismatch in line %d ActualID: expected nil, got %v", i, *respLine.ActualID)
 			} else if expectedLine.ActualID != nil && (respLine.ActualID == nil || *respLine.ActualID != *expectedLine.ActualID) {
 				t.Errorf("mismatch in line %d ActualID: expected %v, got %v", i, *expectedLine.ActualID, respLine.ActualID)
 			}
 
-			// Compare ActualAmount
 			if expectedLine.ActualAmount == nil && respLine.ActualAmount != nil {
 				t.Errorf("mismatch in line %d ActualAmount: expected nil, got %v", i, *respLine.ActualAmount)
 			} else if expectedLine.ActualAmount != nil && (respLine.ActualAmount == nil || *respLine.ActualAmount != *expectedLine.ActualAmount) {
@@ -296,7 +286,7 @@ func TestGetBudgetLinesByMonthIDHandler(t *testing.T) {
 	t.Run("no budget lines found", func(t *testing.T) {
 		monthID := 3
 		mockStore.MockGetBudgetLinesByMonthID = func(mID int) ([]store.BudgetLine, error) {
-			return []store.BudgetLine{}, nil // Empty slice
+			return []store.BudgetLine{}, nil
 		}
 		req := httptest.NewRequest("GET", fmt.Sprintf("/api/v1/budget-lines?month_id=%d", monthID), nil)
 		rr := httptest.NewRecorder()
@@ -376,7 +366,7 @@ func TestUpdateBudgetLineHandler(t *testing.T) {
 	t.Run("budget line not found", func(t *testing.T) {
 		budgetLineID := int64(2)
 		mockStore.MockGetBudgetLineByID = func(id int64) (*store.BudgetLine, error) {
-			return nil, nil // Simulate not found
+			return nil, nil
 		}
 		payload := `{"label":"Any Label"}`
 		req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/budget-lines/%d", budgetLineID), strings.NewReader(payload))
@@ -396,7 +386,7 @@ func TestUpdateBudgetLineHandler(t *testing.T) {
 			t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
 		}
 	})
-	
+
 	t.Run("invalid request body - bad JSON", func(t *testing.T) {
 		req := httptest.NewRequest("PUT", "/api/v1/budget-lines/1", strings.NewReader("{not_json"))
 		rr := httptest.NewRecorder()
@@ -439,7 +429,6 @@ func TestUpdateBudgetLineHandler(t *testing.T) {
 	})
 }
 
-// Helper for tests needing pointers to basic types
 var pointy = struct {
     String  func(s string) *string
     Float64 func(f float64) *float64
@@ -500,10 +489,6 @@ func TestDeleteBudgetLineHandler(t *testing.T) {
 		}
 	})
 
-	// Note: store.DeleteBudgetLine is expected to handle "not found" by returning an error.
-	// If it were to return sql.ErrNoRows specifically and the handler distinguished this,
-	// a separate test for http.StatusNotFound would be appropriate.
-	// Current handler returns InternalServerError for any store error.
 }
 
 func TestUpdateActualLineHandler(t *testing.T) {
@@ -513,14 +498,14 @@ func TestUpdateActualLineHandler(t *testing.T) {
 	t.Run("successful update", func(t *testing.T) {
 		actualLineID := int64(1)
 		originalActualLine := &store.ActualLine{
-			ID:           actualLineID, // Corrected: ID type is int64
+			ID:           actualLineID,
 			BudgetLineID: 10,
 			Actual:       50.00,
 		}
 		updatePayload := struct {
 			Actual *float64 `json:"actual"`
 		}{
-			Actual: pointy.Float64(75.50), // Valid amount
+			Actual: pointy.Float64(75.50),
 		}
 		
 		var capturedActualLine store.ActualLine
@@ -531,7 +516,7 @@ func TestUpdateActualLineHandler(t *testing.T) {
 			return originalActualLine, nil
 		}
 		mockStore.MockUpdateActualLine = func(al *store.ActualLine) error {
-			capturedActualLine = *al // Capture the line passed to the mock
+			capturedActualLine = *al
 			if al.ID != actualLineID || al.Actual != *updatePayload.Actual {
 				t.Errorf("UpdateActualLine called with unexpected data: got %+v, want actual %f", al, *updatePayload.Actual)
 			}
@@ -587,14 +572,13 @@ func TestUpdateActualLineHandler(t *testing.T) {
 		if err := json.Unmarshal(rr.Body.Bytes(), &respBody); err != nil {
 			t.Fatalf("Failed to unmarshal response body: %v", err)
 		}
-		if respBody.Actual != expectedRounded { // Handler should return the store-modified (rounded) value
+		if respBody.Actual != expectedRounded {
 			t.Errorf("expected response actual %.2f, got %.2f", expectedRounded, respBody.Actual)
 		}
 	})
 
 	t.Run("update with negative amount - handler validation", func(t *testing.T) {
 		actualLineID := int64(6)
-		// No need to mock store calls as handler should reject first
 		updatePayload := struct{ Actual *float64 `json:"actual"` }{Actual: pointy.Float64(-10.50)}
 		
 		payloadBytes, _ := json.Marshal(updatePayload)
@@ -611,9 +595,9 @@ func TestUpdateActualLineHandler(t *testing.T) {
 	})
 
 	t.Run("actual line not found", func(t *testing.T) {
-		actualLineID := int64(2) // Corrected: ID type is int64
+		actualLineID := int64(2)
 		mockStore.MockGetActualLineByID = func(id int64) (*store.ActualLine, error) {
-			return nil, nil // Simulate not found
+			return nil, nil
 		}
 		payload := `{"actual":100.0}`
 		req := httptest.NewRequest("PUT", fmt.Sprintf("/api/v1/actual-lines/%d", actualLineID), strings.NewReader(payload))
@@ -633,7 +617,7 @@ func TestUpdateActualLineHandler(t *testing.T) {
 			t.Errorf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
 		}
 	})
-	
+
 	t.Run("invalid request body - bad JSON", func(t *testing.T) {
 		req := httptest.NewRequest("PUT", "/api/v1/actual-lines/1", strings.NewReader("{not_json"))
 		rr := httptest.NewRecorder()
@@ -644,7 +628,7 @@ func TestUpdateActualLineHandler(t *testing.T) {
 	})
 
 	t.Run("missing actual field in body", func(t *testing.T) {
-		req := httptest.NewRequest("PUT", "/api/v1/actual-lines/1", strings.NewReader("{}")) // Empty JSON
+		req := httptest.NewRequest("PUT", "/api/v1/actual-lines/1", strings.NewReader("{}"))
 		rr := httptest.NewRecorder()
 		handler.ServeHTTP(rr, req)
 		if rr.Code != http.StatusBadRequest {
@@ -667,7 +651,7 @@ func TestUpdateActualLineHandler(t *testing.T) {
 	})
 
 	t.Run("store error on UpdateActualLine", func(t *testing.T) {
-		actualLineID := int64(4) // Corrected: ID type is int64
+		actualLineID := int64(4)
 		originalActualLine := &store.ActualLine{ID: actualLineID, Actual: 50.0}
 		mockStore.MockGetActualLineByID = func(id int64) (*store.ActualLine, error) {
 			return originalActualLine, nil

--- a/internal/http/category_handlers.go
+++ b/internal/http/category_handlers.go
@@ -11,10 +11,8 @@ import (
 	"gandalf-budget/internal/store"
 )
 
-// HandleGetCategories ... (as before)
 func HandleGetCategories(storage store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// ... (implementation as before) ...
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -30,10 +28,8 @@ func HandleGetCategories(storage store.Store) http.HandlerFunc {
 	}
 }
 
-// HandleCreateCategory ... (as before)
 func HandleCreateCategory(storage store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// ... (implementation as before) ...
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -59,7 +55,6 @@ func HandleCreateCategory(storage store.Store) http.HandlerFunc {
 	}
 }
 
-// HandleUpdateCategory handles requests to update an existing category.
 func HandleUpdateCategory(storage store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
@@ -67,7 +62,6 @@ func HandleUpdateCategory(storage store.Store) http.HandlerFunc {
 			return
 		}
 
-		// Extract ID from path: /api/v1/categories/:id
 		pathParts := strings.Split(strings.TrimSuffix(r.URL.Path, "/"), "/")
 		idStr := pathParts[len(pathParts)-1]
 
@@ -119,7 +113,6 @@ func HandleUpdateCategory(storage store.Store) http.HandlerFunc {
 	}
 }
 
-// HandleDeleteCategory handles requests to delete an existing category.
 func HandleDeleteCategory(storage store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
@@ -148,6 +141,6 @@ func HandleDeleteCategory(storage store.Store) http.HandlerFunc {
 			return
 		}
 
-		w.WriteHeader(http.StatusNoContent) // 204 No Content for successful delete
+		w.WriteHeader(http.StatusNoContent)
 	}
 }

--- a/internal/http/dashboard_handlers.go
+++ b/internal/http/dashboard_handlers.go
@@ -11,8 +11,6 @@ import (
 	"gandalf-budget/internal/store"
 )
 
-// GetDashboardData handles the request for dashboard data.
-// It expects a "month_id" query parameter.
 func GetDashboardData(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		monthIDStr := r.URL.Query().Get("month_id")
@@ -27,82 +25,49 @@ func GetDashboardData(s store.Store) http.HandlerFunc {
 			return
 		}
 
-		// Fetch board data which now includes month details and budget lines with actuals
-		boardData, err := s.GetBoardData(monthID) // Expects *store.BoardDataPayload
+		boardData, err := s.GetBoardData(monthID)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) { // Assuming store returns sql.ErrNoRows if month not found
+			if errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Month not found", http.StatusNotFound)
 			} else {
 				http.Error(w, "Failed to fetch board data: "+err.Error(), http.StatusInternalServerError)
 			}
 			return
 		}
-		// If boardData is nil for any other reason (should ideally not happen if err is nil)
 		if boardData == nil {
 			http.Error(w, "Failed to retrieve board data (nil payload)", http.StatusInternalServerError)
 			return
 		}
 
-		// Fetch all categories to ensure every category is listed in the dashboard,
-		// even if it has no budget lines for the selected month.
-		allCategories, err := s.GetAllCategories() // Changed from GetCategories
+		allCategories, err := s.GetAllCategories()
 		if err != nil {
 			http.Error(w, "Failed to fetch categories: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		payload := app.DashboardPayload{
-			MonthID: int(boardData.MonthID), // Convert int64 to int
+			MonthID: int(boardData.MonthID),
 			Year:    boardData.Year,
-			Month:   boardData.MonthName, // Directly use MonthName
-			// Totals and summaries will be calculated below
+			Month:   boardData.MonthName,
 		}
 
-		categorySummariesMap := make(map[int64]*app.CategorySummary) // Keyed by CategoryID (int64)
+		categorySummariesMap := make(map[int64]*app.CategorySummary)
 
 		for _, cat := range allCategories {
-			// Ensure cat.ID is int64 if that's the key type
-			// The store.Category has ID int64. app.CategorySummary.CategoryID is int.
-			// This might require a cast or consistent types. Assuming app.CategorySummary.CategoryID is int64 for now.
-			// Let's check app.DashboardPayload definition for CategorySummary.CategoryID type.
-			// app.CategorySummary.CategoryID is int. store.Category.ID is int64.
-			// This is an inconsistency. For now, I'll cast cat.ID to int for map key if necessary,
-			// but the struct fields should align. Assuming app.CategorySummary.CategoryID can be int64.
-			// If app.CategorySummary.CategoryID must be int, then cat.ID needs conversion.
-			// The map key should be int64 to match store.Category.ID.
-			// app.CategorySummary.CategoryID should be int64.
-			// Let's assume app.CategorySummary.CategoryID is changed to int64. (This is outside current scope to change app struct)
-			// For now, I'll use cat.ID (int64) as key and assign to app.CategorySummary.CategoryID (int) with conversion. This is not ideal.
-			// The `app.CategorySummary` has `CategoryID int`.
-			// `store.Category` has `ID int64`.
-			// `store.BudgetLineWithActual` has `CategoryID int64`.
-			// This requires careful casting.
-
-			// Correct approach: categorySummariesMap key should be int64 (category ID type from store.BudgetLineWithActual)
-			// app.CategorySummary.CategoryID should be int64.
-			// For now, I'll assume app.CategorySummary.CategoryID is int as per current app struct.
-
 			categorySummariesMap[cat.ID] = &app.CategorySummary{
-				CategoryID:    int(cat.ID), // store.Category.ID is int64, app.CategorySummary.CategoryID is int
+				CategoryID:    int(cat.ID),
 				CategoryName:  cat.Name,
 				CategoryColor: cat.Color,
 				BudgetLines:   []app.BudgetLineDetail{},
 			}
 		}
 
-		for _, line := range boardData.BudgetLines { // line is store.BudgetLineWithActual
+		for _, line := range boardData.BudgetLines {
 			payload.TotalExpected += line.ExpectedAmount
 			payload.TotalActual += line.ActualAmount
 
 			summary, ok := categorySummariesMap[line.CategoryID]
 			if !ok {
-				// This means a budget line exists for a category not in the allCategories list.
-				// This should ideally not happen if data is consistent.
-				// Or, it means a category was perhaps deleted after budget lines were created.
-				// For robustness, we can create a summary on the fly or log an error.
-				// For now, let's assume if it's not in allCategories, we might skip it or log.
-				// However, BudgetLineWithActual now has CategoryName and CategoryColor.
-				// So, we can create the summary if it doesn't exist.
 				summary = &app.CategorySummary{
 					CategoryID:    int(line.CategoryID),
 					CategoryName:  line.CategoryName,
@@ -116,7 +81,7 @@ func GetDashboardData(s store.Store) http.HandlerFunc {
 			summary.TotalActual += line.ActualAmount
 
 			summary.BudgetLines = append(summary.BudgetLines, app.BudgetLineDetail{
-				BudgetLineID:   int(line.ID), // store.BudgetLineWithActual.ID is int64
+				BudgetLineID:   int(line.ID),
 				Label:          line.Label,
 				ExpectedAmount: line.ExpectedAmount,
 				ActualAmount:   line.ActualAmount,
@@ -124,7 +89,7 @@ func GetDashboardData(s store.Store) http.HandlerFunc {
 			})
 		}
 
-		payload.CategorySummaries = []app.CategorySummary{} // Initialize
+		payload.CategorySummaries = []app.CategorySummary{}
 		for _, summary := range categorySummariesMap {
 			summary.Difference = summary.TotalExpected - summary.TotalActual
 			payload.CategorySummaries = append(payload.CategorySummaries, *summary)

--- a/internal/http/dashboard_handlers_test.go
+++ b/internal/http/dashboard_handlers_test.go
@@ -10,37 +10,10 @@ import (
 	"time"
 
 	"github.com/anaxita/logit/internal/app"
-	"github.com/anaxita/logit/internal/store" // Will use store.ReusableMockStore
-	// "time" // No longer directly used in this file if MockStore is removed
-	// "strings" // No longer directly used in this file if MockStore is removed
+	"github.com/anaxita/logit/internal/store"
 )
 
-// TestGetDashboardData_Success tests the successful retrieval of dashboard data.
 func TestGetDashboardData_Success(t *testing.T) {
-	// The GetDashboardData handler expects GetBoardData to return []store.BudgetLine
-	// and GetCategories to return []store.Category.
-	// The previous local MockStore had MockGetBoardData returning *store.BoardData
-	// and MockGetCategories. We need to align this with the actual store.Store interface
-	// and the ReusableMockStore.
-
-	// Assumed structure for what store.GetBoardData returns (based on store.Store interface)
-	// This is simplified. The actual handler might need more fields if it was relying
-	// on a *store.BoardData struct that contained separate BudgetLines and ActualLines.
-	// For now, we assume store.BudgetLine from GetBoardData contains enough info,
-	// or the handler needs to be adjusted.
-	// The handler seems to iterate over boardData.BudgetLines and boardData.ActualLines
-	// This implies GetBoardData should return a struct containing these two slices.
-	// This conflicts with store.Store's GetBoardData returning []BudgetLine.
-	// This is a pre-existing issue. For this refactoring, I will make the mock
-	// adhere to ReusableMockStore. If GetDashboardData handler is broken due to this
-	// mismatch, that's a separate bug.
-	// Let's assume the GetDashboardData handler is adapted to use GetBudgetLinesByMonthID and GetActualLinesByMonthID
-	// or a new method like GetBoardDataAggregated that returns what it needs.
-	// For now, the dashboard handler uses s.GetBoardData() and s.GetCategories()
-
-	// The GetDashboardData handler now uses s.GetBoardData which returns *store.BoardDataPayload
-	// and s.GetAllCategories.
-
 	mockStore := &store.ReusableMockStore{
 		MockGetBoardData: func(monthID int) (*store.BoardDataPayload, error) {
 			if monthID == 1 {
@@ -52,7 +25,6 @@ func TestGetDashboardData_Success(t *testing.T) {
 						{ID: 101, MonthID: 1, CategoryID: 1, CategoryName: "Food", CategoryColor: "blue", Label: "Groceries", ExpectedAmount: 500.00, ActualAmount: 480.50},
 						{ID: 102, MonthID: 1, CategoryID: 2, CategoryName: "Housing", CategoryColor: "red", Label: "Rent", ExpectedAmount: 1500.00, ActualAmount: 1500.00},
 						{ID: 103, MonthID: 1, CategoryID: 1, CategoryName: "Food", CategoryColor: "blue", Label: "Eating Out", ExpectedAmount: 150.00, ActualAmount: 180.75},
-						// Example of a budget line for a category that might not be in allCategories, but has lines
 						{ID: 104, MonthID: 1, CategoryID: 3, CategoryName: "Utilities", CategoryColor: "green", Label: "Internet", ExpectedAmount: 60.00, ActualAmount: 60.00},
 					},
 				}, nil
@@ -60,14 +32,11 @@ func TestGetDashboardData_Success(t *testing.T) {
 			return nil, errors.New("board data not found for month_id")
 		},
 		MockGetAllCategories: func() ([]store.Category, error) {
-			// These are all categories in the system.
-			// The handler uses this to initialize the map, ensuring all categories appear
-			// even if they don't have budget lines in boardData.BudgetLines.
 			return []store.Category{
 				{ID: 1, Name: "Food", Color: "blue"},
 				{ID: 2, Name: "Housing", Color: "red"},
-				{ID: 3, Name: "Utilities", Color: "green"}, // Included here
-				{ID: 4, Name: "Entertainment", Color: "purple"}, // No budget lines for this one
+				{ID: 3, Name: "Utilities", Color: "green"},
+				{ID: 4, Name: "Entertainment", Color: "purple"},
 			}, nil
 		},
 	}
@@ -89,8 +58,6 @@ func TestGetDashboardData_Success(t *testing.T) {
 		t.Fatalf("could not unmarshal response body: %v. Body: %s", err, rr.Body.String())
 	}
 
-	// Assertions for payload content
-	// Totals from: Groceries (500/480.50), Rent (1500/1500), Eating Out (150/180.75), Internet (60/60)
 	expectedTotalExpected := 500.00 + 1500.00 + 150.00 + 60.00
 	if payload.TotalExpected != expectedTotalExpected {
 		t.Errorf("payload.TotalExpected = %f; want %f", payload.TotalExpected, expectedTotalExpected)
@@ -106,27 +73,24 @@ func TestGetDashboardData_Success(t *testing.T) {
 		t.Errorf("payload.TotalDifference = %f; want %f", payload.TotalDifference, expectedTotalDifference)
 	}
 
-	if payload.MonthID != 1 { // MonthID from BoardDataPayload is int64, converted to int for payload
+	if payload.MonthID != 1 {
 		t.Errorf("payload.MonthID = %d; want %d", payload.MonthID, 1)
 	}
 	if payload.Year != 2023 {
 		t.Errorf("payload.Year = %d; want %d", payload.Year, 2023)
 	}
-	if payload.Month != "December" { // MonthName from BoardDataPayload
+	if payload.Month != "December" {
 		t.Errorf("payload.Month = %s; want %s", payload.Month, "December")
 	}
 
-	// Expect 4 categories: Food, Housing, Utilities (from budget lines) + Entertainment (from allCategories, no lines)
 	if len(payload.CategorySummaries) != 4 {
 		t.Fatalf("len(payload.CategorySummaries) = %d; want %d", len(payload.CategorySummaries), 4)
 	}
 
-	// Category 1: Food
-	// These assertions need to be robust to the order of categories in payload.CategorySummaries
 	var cat1Summary app.CategorySummary
 	foundCat1 := false
 	for _, summary := range payload.CategorySummaries {
-		if summary.CategoryID == 1 { // Assuming Food category ID is 1
+		if summary.CategoryID == 1 {
 			cat1Summary = summary
 			foundCat1 = true
 			break
@@ -155,11 +119,10 @@ func TestGetDashboardData_Success(t *testing.T) {
 		t.Errorf("len(cat1Summary.BudgetLines) = %d; want %d", len(cat1Summary.BudgetLines), 2)
 	}
 
-	// Check a budget line detail within category 1 (e.g., Groceries)
 	var bl1_1 app.BudgetLineDetail
 	foundBL1_1 := false
 	for _, bl := range cat1Summary.BudgetLines {
-		if bl.Label == "Groceries" { // Assuming label is unique for this test
+		if bl.Label == "Groceries" {
 			bl1_1 = bl
 			foundBL1_1 = true
 			break
@@ -179,12 +142,10 @@ func TestGetDashboardData_Success(t *testing.T) {
 		t.Errorf("Groceries Difference = %f; want %f", bl1_1.Difference, (500.00 - 480.50))
 	}
 
-
-	// Category 2: Housing
 	var cat2Summary app.CategorySummary
 	foundCat2 := false
 	for _, summary := range payload.CategorySummaries {
-		if summary.CategoryID == 2 { // Assuming Housing category ID is 2
+		if summary.CategoryID == 2 {
 			cat2Summary = summary
 			foundCat2 = true
 			break
@@ -196,7 +157,6 @@ func TestGetDashboardData_Success(t *testing.T) {
 	if cat2Summary.CategoryName != "Housing" {
 		t.Errorf("cat2Summary.CategoryName = %s; want Housing", cat2Summary.CategoryName)
 	}
-
 
 	expectedCat2TotalExpected := 1500.00
 	if cat2Summary.TotalExpected != expectedCat2TotalExpected {
@@ -211,9 +171,8 @@ func TestGetDashboardData_Success(t *testing.T) {
 	}
 }
 
-// TestGetDashboardData_InvalidMonthID tests behavior with a non-integer month_id.
 func TestGetDashboardData_InvalidMonthID(t *testing.T) {
-	mockStore := &store.ReusableMockStore{} // Store interaction not expected
+	mockStore := &store.ReusableMockStore{}
 	handler := GetDashboardData(mockStore)
 
 	req := httptest.NewRequest("GET", "/api/v1/dashboard?month_id=abc", nil)
@@ -230,12 +189,11 @@ func TestGetDashboardData_InvalidMonthID(t *testing.T) {
 	}
 }
 
-// TestGetDashboardData_MonthIDRequired tests behavior when month_id is missing.
 func TestGetDashboardData_MonthIDRequired(t *testing.T) {
-	mockStore := &store.ReusableMockStore{} // Store interaction not expected
+	mockStore := &store.ReusableMockStore{}
 	handler := GetDashboardData(mockStore)
 
-	req := httptest.NewRequest("GET", "/api/v1/dashboard", nil) // No month_id
+	req := httptest.NewRequest("GET", "/api/v1/dashboard", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
@@ -249,12 +207,10 @@ func TestGetDashboardData_MonthIDRequired(t *testing.T) {
 	}
 }
 
-
-// TestGetDashboardData_MonthNotFound tests behavior when month_id is not found.
 func TestGetDashboardData_MonthNotFound(t *testing.T) {
 	mockStore := &store.ReusableMockStore{
 		MockGetMonthByID: func(id int) (*store.Month, error) {
-			return nil, sql.ErrNoRows // Simulate month not found
+			return nil, sql.ErrNoRows
 		},
 	}
 	handler := GetDashboardData(mockStore)
@@ -272,7 +228,6 @@ func TestGetDashboardData_MonthNotFound(t *testing.T) {
 	}
 }
 
-// TestGetDashboardData_ErrorGetMonthByID_Other tests GetMonthByID returning a non-ErrNoRows error.
 func TestGetDashboardData_ErrorGetMonthByID_Other(t *testing.T) {
 	mockStore := &store.ReusableMockStore{
 		MockGetMonthByID: func(id int) (*store.Month, error) {
@@ -293,16 +248,13 @@ func TestGetDashboardData_ErrorGetMonthByID_Other(t *testing.T) {
 	}
 }
 
-
-// TestGetDashboardData_ErrorGetBoardData tests behavior when GetBoardData fails.
 func TestGetDashboardData_ErrorGetBoardData(t *testing.T) {
 	mockStore := &store.ReusableMockStore{
 		MockGetMonthByID: func(id int) (*store.Month, error) {
-			// Assuming store.Month.Month is int, handler needs to convert to string for payload.Month
 			return &store.Month{ID: 1, Year: 2023, Month: 12}, nil
 		},
-		MockGetBoardData: func(monthID int) ([]store.BudgetLine, error) { // Aligned with store.Store
-			return nil, errors.New("failed to fetch board data") // Simulate error
+		MockGetBoardData: func(monthID int) ([]store.BudgetLine, error) {
+			return nil, errors.New("failed to fetch board data")
 		},
 	}
 	handler := GetDashboardData(mockStore)
@@ -314,25 +266,22 @@ func TestGetDashboardData_ErrorGetBoardData(t *testing.T) {
 	if status := rr.Code; status != http.StatusInternalServerError {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusInternalServerError)
 	}
-	expectedErrorMsg := "Failed to fetch board data" // This error comes from the handler
+	expectedErrorMsg := "Failed to fetch board data"
 	if body := rr.Body.String(); !strings.Contains(body, expectedErrorMsg) {
 		t.Errorf("handler returned unexpected body: got '%s' want to contain '%s'", body, expectedErrorMsg)
 	}
 }
 
-// TestGetDashboardData_ErrorGetCategories tests behavior when GetCategories fails.
-// Assuming handler uses s.GetAllCategories() now.
 func TestGetDashboardData_ErrorGetAllCategories(t *testing.T) {
 	mockStore := &store.ReusableMockStore{
 		MockGetMonthByID: func(id int) (*store.Month, error) {
 			return &store.Month{ID: 1, Year: 2023, Month: 12}, nil
 		},
 		MockGetBoardData: func(monthID int) ([]store.BudgetLine, error) {
-			// Return some valid board data, error will be in GetAllCategories
 			return []store.BudgetLine{}, nil
 		},
-		MockGetAllCategories: func() ([]store.Category, error) { // Changed from MockGetCategories
-			return nil, errors.New("failed to fetch categories") // Simulate error
+		MockGetAllCategories: func() ([]store.Category, error) {
+			return nil, errors.New("failed to fetch categories")
 		},
 	}
 	handler := GetDashboardData(mockStore)
@@ -350,9 +299,6 @@ func TestGetDashboardData_ErrorGetAllCategories(t *testing.T) {
 	}
 }
 
-// Helper to compare float64 values with a tolerance
-// This function is not used in the current tests after refactoring assertions.
-// Keeping it here in case it's useful for other tests or future adjustments.
 func floatEquals(a, b, tolerance float64) bool {
 	if (a-b) < tolerance && (b-a) < tolerance {
 		return true
@@ -360,12 +306,6 @@ func floatEquals(a, b, tolerance float64) bool {
 	return false
 }
 
-// You might need to adjust the TestGetDashboardData_Success assertions
-// if the order of CategorySummaries or BudgetLines is not guaranteed.
-// For example, you might iterate and find items by ID/Name instead of relying on index.
-// The current success test has been updated to be more robust to ordering.
-
 func TestMain(m *testing.M) {
-	// You can add setup/teardown here if needed for all tests in this package
 	m.Run()
 }

--- a/internal/http/mock_store_test.go
+++ b/internal/http/mock_store_test.go
@@ -1,19 +1,16 @@
 package http
 
 import (
-	"gandalf-budget/internal/store" // Import the actual store package
+	"gandalf-budget/internal/store"
 )
 
-// MockStore is a mock implementation of the store.Store interface for testing HTTP handlers.
 type MockStore struct {
-	// --- Category methods ---
 	GetAllCategoriesFunc    func() ([]store.Category, error)
 	CreateCategoryFunc      func(category *store.Category) error
 	GetCategoryByIDFunc     func(id int64) (*store.Category, error)
 	UpdateCategoryFunc      func(category *store.Category) error
 	DeleteCategoryFunc      func(id int64) error
 
-	// --- BudgetLine and ActualLine methods ---
 	CreateBudgetLineFunc        func(b *store.BudgetLine) (int64, error)
 	GetBudgetLinesByMonthIDFunc func(monthID int) ([]store.BudgetLine, error)
 	UpdateBudgetLineFunc        func(b *store.BudgetLine) error
@@ -22,20 +19,17 @@ type MockStore struct {
 	GetActualLineByIDFunc       func(id int64) (*store.ActualLine, error)
 	GetBudgetLineByIDFunc       func(id int64) (*store.BudgetLine, error)
 
-	// --- Board data methods ---
 	GetBoardDataFunc func(monthID int) ([]store.BudgetLine, error)
 
-	// --- Month finalization methods ---
 	CanFinalizeMonthFunc func(monthID int) (bool, string, error)
 	FinalizeMonthFunc    func(monthID int, snapJSON string) (int64, error)
 }
 
-// --- Category methods implementation ---
 func (m *MockStore) GetAllCategories() ([]store.Category, error) {
 	if m.GetAllCategoriesFunc != nil {
 		return m.GetAllCategoriesFunc()
 	}
-	return nil, nil // Default behavior
+	return nil, nil
 }
 func (m *MockStore) CreateCategory(category *store.Category) error {
 	if m.CreateCategoryFunc != nil {
@@ -62,7 +56,6 @@ func (m *MockStore) DeleteCategory(id int64) error {
 	return nil
 }
 
-// --- BudgetLine and ActualLine methods implementation ---
 func (m *MockStore) CreateBudgetLine(b *store.BudgetLine) (int64, error) {
 	if m.CreateBudgetLineFunc != nil {
 		return m.CreateBudgetLineFunc(b)
@@ -106,24 +99,22 @@ func (m *MockStore) GetBudgetLineByID(id int64) (*store.BudgetLine, error) {
 	return nil, nil
 }
 
-// --- Board data methods implementation ---
 func (m *MockStore) GetBoardData(monthID int) ([]store.BudgetLine, error) {
 	if m.GetBoardDataFunc != nil {
 		return m.GetBoardDataFunc(monthID)
 	}
-	return nil, nil // Default behavior
+	return nil, nil
 }
 
-// --- Month finalization methods implementation ---
 func (m *MockStore) CanFinalizeMonth(monthID int) (bool, string, error) {
 	if m.CanFinalizeMonthFunc != nil {
 		return m.CanFinalizeMonthFunc(monthID)
 	}
-	return false, "", nil // Default behavior
+	return false, "", nil
 }
 func (m *MockStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 	if m.FinalizeMonthFunc != nil {
 		return m.FinalizeMonthFunc(monthID, snapJSON)
 	}
-	return 0, nil // Default behavior
+	return 0, nil
 }

--- a/internal/http/month_handlers.go
+++ b/internal/http/month_handlers.go
@@ -10,7 +10,6 @@ import (
 	"gandalf-budget/internal/store"
 )
 
-// FinalizeMonthHandler handles the logic for finalizing a month.
 func FinalizeMonthHandler(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
@@ -31,7 +30,6 @@ func FinalizeMonthHandler(s store.Store) http.HandlerFunc {
 			return
 		}
 
-		// 1. Check if month can be finalized
 		canFinalize, reason, err := s.CanFinalizeMonth(monthID)
 		if err != nil {
 			log.Printf("Error checking if month %d can be finalized: %v", monthID, err)
@@ -39,13 +37,10 @@ func FinalizeMonthHandler(s store.Store) http.HandlerFunc {
 			return
 		}
 		if !canFinalize {
-			http.Error(w, reason, http.StatusBadRequest) // Send the reason to the client
+			http.Error(w, reason, http.StatusBadRequest)
 			return
 		}
 
-		// 2. Define dashboard payload for snapshot (using GetBoardData for now)
-		// This part assumes GetBoardData is suitable for the snapshot.
-		// It might need adjustment based on actual dashboard requirements in Milestone 5.
 		boardData, err := s.GetBoardData(monthID)
 		if err != nil {
 			log.Printf("Error fetching board data for snapshot (month %d): %v", monthID, err)
@@ -60,7 +55,6 @@ func FinalizeMonthHandler(s store.Store) http.HandlerFunc {
 		}
 		snapJSON := string(snapJSONBytes)
 
-		// 3. Finalize the month
 		newMonthID, err := s.FinalizeMonth(monthID, snapJSON)
 		if err != nil {
 			log.Printf("Error finalizing month %d: %v", monthID, err)
@@ -68,7 +62,6 @@ func FinalizeMonthHandler(s store.Store) http.HandlerFunc {
 			return
 		}
 
-		// 4. Respond with success
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"message":      "Month finalized successfully",

--- a/internal/http/report_handlers.go
+++ b/internal/http/report_handlers.go
@@ -13,8 +13,6 @@ import (
 	"gandalf-budget/internal/store"
 )
 
-// GetAnnualReport handles requests for annual report data.
-// It expects a "year" query parameter.
 func GetAnnualReport(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		yearStr := r.URL.Query().Get("year")
@@ -28,45 +26,31 @@ func GetAnnualReport(s store.Store) http.HandlerFunc {
 			http.Error(w, "Invalid year format: must be an integer", http.StatusBadRequest)
 			return
 		}
-		// Basic validation for a reasonable year range
 		currentYear := time.Now().Year()
-		if year < 2000 || year > currentYear+5 { // Allow a bit into the future for planning
+		if year < 2000 || year > currentYear+5 {
 			http.Error(w, "Year out of reasonable range", http.StatusBadRequest)
 			return
 		}
 
 		snapshotsMeta, err := s.GetAnnualSnapshotsMetadataByYear(year)
 		if err != nil {
-			// Log the error for server-side visibility
-			// Consider a more specific error for "not found" if that's distinct from a general store error
-			// For now, any error from the store is treated as a 500.
 			http.Error(w, "Failed to retrieve annual report data: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		// If snapshotsMeta is nil (which can happen if the store returns nil, nil),
-		// convert it to an empty slice for JSON marshalling to ensure `[]` instead of `null`.
 		if snapshotsMeta == nil {
 			snapshotsMeta = []store.AnnualSnapMeta{}
 		}
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(snapshotsMeta); err != nil {
-			// Log this error as well
 			http.Error(w, "Failed to marshal JSON response: "+err.Error(), http.StatusInternalServerError)
 		}
 	}
 }
 
-// GetSnapshotDetail handles requests for a specific annual snapshot's JSON data.
-// It expects a "snapId" as part of the URL path.
 func GetSnapshotDetail(s store.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Path: /api/v1/reports/snapshots/{snapId}
-		// Since we are using http.ServeMux, we need to parse the ID from the path manually.
-		// Example: /api/v1/reports/snapshots/123
-		// We expect the router to register this for a path prefix like "/api/v1/reports/snapshots/"
-		// and then we extract the part after the prefix.
 		pathPrefix := "/api/v1/reports/snapshots/"
 		idStr := strings.TrimPrefix(r.URL.Path, pathPrefix)
 
@@ -83,23 +67,17 @@ func GetSnapshotDetail(s store.Store) http.HandlerFunc {
 
 		snapJSON, err := s.GetAnnualSnapshotJSONByID(snapID)
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) { // Make sure to import "database/sql"
+			if errors.Is(err, sql.ErrNoRows) {
 				http.Error(w, "Snapshot not found", http.StatusNotFound)
 			} else {
-				// Log the error for server-side visibility
 				http.Error(w, "Failed to retrieve snapshot data: "+err.Error(), http.StatusInternalServerError)
 			}
 			return
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		// Write the JSON string directly. No need to re-encode if it's already JSON.
-		// Ensure snapJSON is indeed a JSON string.
 		_, err = w.Write([]byte(snapJSON))
 		if err != nil {
-			// This error usually happens if the connection is closed or there's an issue writing.
-			// Log it, but the header might have already been sent.
-			// Consider logging this, but it's hard to send a different HTTP error at this point.
 			log.Printf("Error writing snapshot JSON to response for ID %d: %v", snapID, err)
 		}
 	}

--- a/internal/store/board_store.go
+++ b/internal/store/board_store.go
@@ -4,13 +4,10 @@ import (
 	"fmt" // For error formatting
 	// Other necessary imports like "database/sql" if doing complex scanning,
 	// but sqlx should handle it.
-	"database/sql" // For sql.ErrNoRows
+	"database/sql"
 )
 
-// GetBoardData retrieves comprehensive data for the monthly budget board.
-// It includes month details and all budget lines with their actuals and category info.
 func (s *sqlStore) GetBoardData(monthID int) (*BoardDataPayload, error) {
-	// 1. Fetch month details
 	var monthDetails struct {
 		Year  int `db:"year"`
 		Month int `db:"month"`
@@ -19,7 +16,7 @@ func (s *sqlStore) GetBoardData(monthID int) (*BoardDataPayload, error) {
 	err := s.DB.Get(&monthDetails, monthQuery, monthID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, sql.ErrNoRows // Month not found
+			return nil, sql.ErrNoRows
 		}
 		return nil, fmt.Errorf("error fetching month details for month ID %d: %w", monthID, err)
 	}
@@ -41,7 +38,6 @@ func (s *sqlStore) GetBoardData(monthID int) (*BoardDataPayload, error) {
 	default: monthName = "Unknown"
 	}
 
-	// 2. Fetch budget lines with actuals and category info
 	var budgetLinesWithActuals []BudgetLineWithActual
 	query := `
 	SELECT
@@ -52,27 +48,20 @@ func (s *sqlStore) GetBoardData(monthID int) (*BoardDataPayload, error) {
 		c.color AS category_color,
 		bl.label,
 		bl.expected AS expected_amount,
-		COALESCE(al.actual, 0) AS actual_amount 
-		-- Using COALESCE to ensure actual_amount is 0 if no matching actual_line,
-		-- assuming actual_lines might be missing for newly created budget_lines
-		-- or if ActualID on BudgetLine is nullable and not set.
-		-- The PRD implies actual_lines are auto-created, so LEFT JOIN might be sufficient
-		-- if actual_lines.actual can be NULL. If actual_lines.actual is NOT NULL and defaults to 0,
-		-- then COALESCE is still safe.
+		COALESCE(al.actual, 0) AS actual_amount
 	FROM budget_lines bl
 	JOIN categories c ON bl.category_id = c.id
 	LEFT JOIN actual_lines al ON bl.id = al.budget_line_id
 	WHERE bl.month_id = ?
-	ORDER BY c.name, bl.label; -- Meaningful order
+	ORDER BY c.name, bl.label;
 	`
 	err = s.DB.Select(&budgetLinesWithActuals, query, monthID)
-	if err != nil && err != sql.ErrNoRows { // sql.ErrNoRows is ok here, means no budget lines
+	if err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("error fetching budget lines with actuals for month %d: %w", monthID, err)
 	}
-	// If err is sql.ErrNoRows, budgetLinesWithActuals will be an empty slice, which is correct.
 
 	payload := &BoardDataPayload{
-		MonthID:     int64(monthID), // Convert int to int64 if your struct field is int64
+		MonthID:     int64(monthID),
 		Year:        monthDetails.Year,
 		MonthName:   monthName,
 		BudgetLines: budgetLinesWithActuals,

--- a/internal/store/board_store_test.go
+++ b/internal/store/board_store_test.go
@@ -3,35 +3,29 @@ package store
 import (
 	"reflect"
 	"testing"
-	// "github.com/jmoiron/sqlx" // Implicitly used via sqlStore
 )
 
 func TestGetBoardData(t *testing.T) {
-	db := newTestDB(t) // Uses the helper from store_test_setup_test.go
-	s := NewSQLStore(db).(*sqlStore) // Assuming NewSQLStore returns the interface, cast to access DB directly or use methods
+	db := newTestDB(t)
+	s := NewSQLStore(db).(*sqlStore)
 
-	// Setup initial data
 	cat1ID := createTestCategory(t, db, "Food", "bg-red-500")
 	cat2ID := createTestCategory(t, db, "Travel", "bg-blue-500")
 
 	month1ID := createTestMonth(t, db, 2023, 1, false)
-	month2ID := createTestMonth(t, db, 2023, 2, false) // Month with no budget lines
-	month3ID := createTestMonth(t, db, 2023, 3, false) // Month with lines but no actuals
+	month2ID := createTestMonth(t, db, 2023, 2, false)
+	month3ID := createTestMonth(t, db, 2023, 3, false)
 
-	// Budget lines for month 1
 	bl1m1 := createTestBudgetLine(t, db, month1ID, cat1ID, "Groceries", 500.0)
 	bl2m1 := createTestBudgetLine(t, db, month1ID, cat2ID, "Gas", 100.0)
 	createTestActualLine(t, db, bl1m1, 480.0)
 	createTestActualLine(t, db, bl2m1, 110.0)
 
-	// Budget lines for month 3 (no actuals, or actuals are 0)
 	bl1m3 := createTestBudgetLine(t, db, month3ID, cat1ID, "Restaurant", 150.0)
-	createTestActualLine(t, db, bl1m3, 0) // Actual line with 0 value
+	createTestActualLine(t, db, bl1m3, 0)
 	
 	bl2m3 := createTestBudgetLine(t, db, month3ID, cat2ID, "Bus Pass", 50.0)
-	// No actual line for bl2m3, so actual_id and actual_amount should be nil/zero depending on join
 
-	// Define test cases
 	tests := []struct {
 		name          string
 		monthID       int
@@ -42,26 +36,22 @@ func TestGetBoardData(t *testing.T) {
 			name:    "Month with budget lines and actual lines",
 			monthID: int(month1ID),
 			expectedLines: []BudgetLine{
-				{ID: int(bl1m1), MonthID: int(month1ID), CategoryID: int(cat1ID), Label: "Groceries", Expected: 500.0, ActualID: ptrToInt64(1), ActualAmount: ptrToFloat64(480.0)}, // Assuming actual_id is 1
-				{ID: int(bl2m1), MonthID: int(month1ID), CategoryID: int(cat2ID), Label: "Gas", Expected: 100.0, ActualID: ptrToInt64(2), ActualAmount: ptrToFloat64(110.0)}, // Assuming actual_id is 2
+				{ID: int(bl1m1), MonthID: int(month1ID), CategoryID: int(cat1ID), Label: "Groceries", Expected: 500.0, ActualID: ptrToInt64(1), ActualAmount: ptrToFloat64(480.0)},
+				{ID: int(bl2m1), MonthID: int(month1ID), CategoryID: int(cat2ID), Label: "Gas", Expected: 100.0, ActualID: ptrToInt64(2), ActualAmount: ptrToFloat64(110.0)},
 			},
 			expectError: false,
 		},
 		{
 			name:          "Month with no budget lines",
 			monthID:       int(month2ID),
-			expectedLines: []BudgetLine{}, // Expect an empty slice, not nil
+			expectedLines: []BudgetLine{},
 			expectError:   false,
 		},
 		{
 			name:    "Month with lines but varied actuals",
 			monthID: int(month3ID),
 			expectedLines: []BudgetLine{
-				// For bl1m3, actual_lines.id will be 3, actual_lines.actual is 0
 				{ID: int(bl1m3), MonthID: int(month3ID), CategoryID: int(cat1ID), Label: "Restaurant", Expected: 150.0, ActualID: ptrToInt64(3), ActualAmount: ptrToFloat64(0.0)},
-				// For bl2m3, there's no corresponding actual_lines record, so ActualID and ActualAmount should be nil (or zero if coalesce is used in query)
-				// The current GetBoardData query uses LEFT JOIN, so ActualID and ActualAmount will be nil for bl2m3.
-				// The BudgetLine struct uses pointers for ActualID and ActualAmount to handle this.
 				{ID: int(bl2m3), MonthID: int(month3ID), CategoryID: int(cat2ID), Label: "Bus Pass", Expected: 50.0, ActualID: nil, ActualAmount: nil},
 			},
 			expectError: false,
@@ -69,8 +59,8 @@ func TestGetBoardData(t *testing.T) {
 		{
 			name:          "Invalid monthID (non-existent)",
 			monthID:       999,
-			expectedLines: []BudgetLine{}, // Expect an empty slice for non-existent month
-			expectError:   false,          // The function itself doesn't error, just returns no lines
+			expectedLines: []BudgetLine{},
+			expectError:   false,
 		},
 	}
 
@@ -82,26 +72,19 @@ func TestGetBoardData(t *testing.T) {
 				if err == nil {
 					t.Errorf("Expected an error, but got nil")
 				}
-				return // Don't check lines if error was expected
+				return
 			}
 			if err != nil {
 				t.Fatalf("Did not expect an error, but got: %v", err)
 			}
 
-			// Normalize actual_id if it's 0 due to no record vs. actual record with ID 0 (not possible with autoincrement)
-			// For this test, we assume actual_id starts from 1.
-			// The important part is comparing the structure and relevant values.
-			// reflect.DeepEqual is strict with nil vs empty.
 			if len(lines) == 0 && len(tc.expectedLines) == 0 {
-				// Both are empty, so they are equal in this context.
 			} else if !reflect.DeepEqual(lines, tc.expectedLines) {
 				t.Errorf("Expected lines %+v, but got %+v", tc.expectedLines, lines)
-				// For detailed comparison:
 				for i := 0; i < len(lines) || i < len(tc.expectedLines); i++ {
 					if i < len(lines) && i < len(tc.expectedLines) {
 						if !reflect.DeepEqual(lines[i], tc.expectedLines[i]) {
 							t.Logf("Difference at index %d: Expected %+v, Got %+v", i, tc.expectedLines[i], lines[i])
-							// Further breakdown by field if needed
 							if !reflect.DeepEqual(lines[i].ActualID, tc.expectedLines[i].ActualID) {
 								t.Logf("  ActualID diff: Expected %v, Got %v", tc.expectedLines[i].ActualID, lines[i].ActualID)
 							}
@@ -120,12 +103,10 @@ func TestGetBoardData(t *testing.T) {
 	}
 }
 
-// Helper function to get a pointer to an int64 value.
 func ptrToInt64(v int64) *int64 {
 	return &v
 }
 
-// Helper function to get a pointer to a float64 value.
 func ptrToFloat64(v float64) *float64 {
 	return &v
 }

--- a/internal/store/categories.go
+++ b/internal/store/categories.go
@@ -6,10 +6,6 @@ import (
 	"log"
 )
 
-// Category struct (as defined in models.go)
-
-// GetAllCategories retrieves all categories from the database, ordered by name.
-// It returns an empty slice if no categories are found.
 func (s *sqlStore) GetAllCategories() ([]Category, error) {
 	var categories []Category
 	err := s.DB.Select(&categories, "SELECT id, name, color FROM categories ORDER BY name ASC")
@@ -23,9 +19,6 @@ func (s *sqlStore) GetAllCategories() ([]Category, error) {
 	return categories, nil
 }
 
-// CreateCategory inserts a new category into the database.
-// It requires Name and Color to be set on the Category struct.
-// The ID of the newly created category is set on the input Category struct.
 func (s *sqlStore) CreateCategory(category *Category) error {
 	if category.Name == "" {
 		return fmt.Errorf("category name cannot be empty")
@@ -49,15 +42,13 @@ func (s *sqlStore) CreateCategory(category *Category) error {
 	return nil
 }
 
-// GetCategoryByID retrieves a single category by its ID.
-// It returns nil if the category is not found.
 func (s *sqlStore) GetCategoryByID(id int64) (*Category, error) {
 	var category Category
 	err := s.DB.Get(&category, "SELECT id, name, color FROM categories WHERE id = ?", id)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			log.Printf("Category with ID %d not found: %v", id, err)
-			return nil, nil // Or a specific "not found" error
+			return nil, nil
 		}
 		log.Printf("Error getting category by ID %d: %v", id, err)
 		return nil, err
@@ -65,9 +56,6 @@ func (s *sqlStore) GetCategoryByID(id int64) (*Category, error) {
 	return &category, nil
 }
 
-// UpdateCategory updates an existing category in the database.
-// It requires ID, Name, and Color to be set on the Category struct.
-// Returns sql.ErrNoRows if no category with the given ID is found or if data was the same.
 func (s *sqlStore) UpdateCategory(category *Category) error {
 	if category.ID == 0 {
 		return fmt.Errorf("category ID cannot be zero for update")
@@ -92,14 +80,12 @@ func (s *sqlStore) UpdateCategory(category *Category) error {
 	}
 	if rowsAffected == 0 {
 		log.Printf("No category found with ID %d to update, or data was the same.", category.ID)
-		return sql.ErrNoRows // Use sql.ErrNoRows to indicate not found or no change
+		return sql.ErrNoRows
 	}
 	log.Printf("Successfully updated category ID %d", category.ID)
 	return nil
 }
 
-// DeleteCategory removes a category from the database by its ID.
-// Returns sql.ErrNoRows if no category with the given ID is found.
 func (s *sqlStore) DeleteCategory(id int64) error {
 	if id == 0 {
 		return fmt.Errorf("category ID cannot be zero for delete")
@@ -120,7 +106,7 @@ func (s *sqlStore) DeleteCategory(id int64) error {
 
 	if rowsAffected == 0 {
 		log.Printf("No category found with ID %d to delete.", id)
-		return sql.ErrNoRows // Use sql.ErrNoRows to indicate not found
+		return sql.ErrNoRows
 	}
 
 	log.Printf("Successfully deleted category ID %d", id)

--- a/internal/store/mock_store.go
+++ b/internal/store/mock_store.go
@@ -2,23 +2,15 @@ package store
 
 import (
 	"errors"
-	// Assuming your model types (Category, BudgetLine, ActualLine, AnnualSnapMeta, Month)
-	// are defined in this 'store' package (e.g., in models.go).
-	// If they are in a different package, adjust import paths accordingly.
-	// "time" // Only if time.Time is directly used in a method signature, not just within structs
 )
 
-// ReusableMockStore is a mock implementation of the Store interface
-// that can be reused across different test packages.
 type ReusableMockStore struct {
-	// Category methods
 	MockGetAllCategories func() ([]Category, error)
 	MockCreateCategory   func(category *Category) error
 	MockGetCategoryByID  func(id int64) (*Category, error)
 	MockUpdateCategory   func(category *Category) error
 	MockDeleteCategory   func(id int64) error
 
-	// BudgetLine and ActualLine methods
 	MockCreateBudgetLine        func(b *BudgetLine) (int64, error)
 	MockGetBudgetLinesByMonthID func(monthID int) ([]BudgetLine, error)
 	MockUpdateBudgetLine        func(b *BudgetLine) error
@@ -27,29 +19,14 @@ type ReusableMockStore struct {
 	MockGetActualLineByID       func(id int64) (*ActualLine, error)
 	MockGetBudgetLineByID       func(id int64) (*BudgetLine, error)
 
-	// Board data methods
-	// The interface has: GetBoardData(monthID int) ([]BudgetLine, error)
 	MockGetBoardData func(monthID int) ([]BudgetLine, error)
 
-	// Month finalization methods
 	MockCanFinalizeMonth func(monthID int) (bool, string, error)
 	MockFinalizeMonth    func(monthID int, snapJSON string) (int64, error)
 
-	// Report methods
 	MockGetAnnualSnapshotsMetadataByYear func(year int) ([]AnnualSnapMeta, error)
 	MockGetAnnualSnapshotJSONByID        func(snapID int64) (string, error)
-
-	// NOTE: The following methods were found in some test mocks but are NOT part of the
-	// current store.Store interface definition based on the last review:
-	// MockGetMonthByID      func(id int) (*Month, error)
-	// MockGetCategories     func() ([]Category, error) // This is GetAllCategories
-	// MockGetBudgetLinesWithActualsByMonthID func(monthID int) ([]BudgetLineWithActuals, error)
-	// MockGetLatestMonth           func() (*Month, error)
-	// MockCreateMonth              func(year int, monthName string) (int64, error)
-	// If these are needed, the store.Store interface itself must be updated first.
 }
-
-// --- Category methods ---
 
 func (m *ReusableMockStore) GetAllCategories() ([]Category, error) {
 	if m.MockGetAllCategories != nil {
@@ -85,8 +62,6 @@ func (m *ReusableMockStore) DeleteCategory(id int64) error {
 	}
 	return errors.New("ReusableMockStore: MockDeleteCategory not implemented")
 }
-
-// --- BudgetLine and ActualLine methods ---
 
 func (m *ReusableMockStore) CreateBudgetLine(b *BudgetLine) (int64, error) {
 	if m.MockCreateBudgetLine != nil {
@@ -137,16 +112,12 @@ func (m *ReusableMockStore) GetBudgetLineByID(id int64) (*BudgetLine, error) {
 	return nil, errors.New("ReusableMockStore: MockGetBudgetLineByID not implemented")
 }
 
-// --- Board data methods ---
-
 func (m *ReusableMockStore) GetBoardData(monthID int) ([]BudgetLine, error) {
 	if m.MockGetBoardData != nil {
 		return m.MockGetBoardData(monthID)
 	}
 	return nil, errors.New("ReusableMockStore: MockGetBoardData not implemented")
 }
-
-// --- Month finalization methods ---
 
 func (m *ReusableMockStore) CanFinalizeMonth(monthID int) (bool, string, error) {
 	if m.MockCanFinalizeMonth != nil {
@@ -161,8 +132,6 @@ func (m *ReusableMockStore) FinalizeMonth(monthID int, snapJSON string) (int64, 
 	}
 	return 0, errors.New("ReusableMockStore: MockFinalizeMonth not implemented")
 }
-
-// --- Report methods ---
 
 func (m *ReusableMockStore) GetAnnualSnapshotsMetadataByYear(year int) ([]AnnualSnapMeta, error) {
 	if m.MockGetAnnualSnapshotsMetadataByYear != nil {

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -2,14 +2,12 @@ package store
 
 import "time"
 
-// Category represents a budget category.
 type Category struct {
 	ID    int64  `json:"id" db:"id"`
 	Name  string `json:"name" db:"name"`
-	Color string `json:"color" db:"color"` // Tailwind color class
+	Color string `json:"color" db:"color"`
 }
 
-// Add other models here as needed, e.g.:
 type Month struct {
 	ID        int64 `json:"id" db:"id"`
 	Year      int   `json:"year" db:"year"`
@@ -17,57 +15,51 @@ type Month struct {
 	Finalized bool  `json:"finalized" db:"finalized"`
 }
 
-// BudgetLine represents a line item in a monthly budget.
 type BudgetLine struct {
 	ID           int     `json:"id" db:"id"`
 	MonthID      int     `json:"month_id" db:"month_id"`
 	CategoryID   int     `json:"category_id" db:"category_id"`
 	Label        string  `json:"label" db:"label"`
 	Expected     float64 `json:"expected" db:"expected"`
-	ActualID     *int64  `json:"actual_id,omitempty" db:"actual_id"`         // New field
-	ActualAmount *float64 `json:"actual_amount,omitempty" db:"actual_amount"` // New field
+	ActualID     *int64  `json:"actual_id,omitempty" db:"actual_id"`
+	ActualAmount *float64 `json:"actual_amount,omitempty" db:"actual_amount"`
 }
 
-// ActualLine represents the actual spending for a budget line.
 type ActualLine struct {
-	ID           int64   `json:"id" db:"id"` // Changed to int64 to match ActualID in BudgetLine
-	BudgetLineID int64   `json:"budget_line_id" db:"budget_line_id"` // Changed to int64
+	ID           int64   `json:"id" db:"id"`
+	BudgetLineID int64   `json:"budget_line_id" db:"budget_line_id"`
 	Actual       float64 `json:"actual" db:"actual"`
 }
 
 type AnnualSnap struct {
 	ID        int64  `json:"id" db:"id"`
-	MonthID   int64  `json:"month_id" db:"month_id"` // Assuming month IDs can be int64
+	MonthID   int64  `json:"month_id" db:"month_id"`
 	SnapJSON  string `json:"snap_json" db:"snap_json"`
-	CreatedAt string `json:"created_at" db:"created_at"` // Or time.Time, but string is simpler for now if PRD implies DATETIME text
+	CreatedAt string `json:"created_at" db:"created_at"`
 }
 
-// AnnualSnapMeta represents metadata for an annual snapshot.
 type AnnualSnapMeta struct {
 	ID            int64     `json:"id" db:"id"`
 	MonthID       int64     `json:"month_id" db:"month_id"`
-	Year          int       `json:"year" db:"year"`        // Year of the snapshot's month
-	Month         string    `json:"month" db:"month_name"` // Name of the snapshot's month
+	Year          int       `json:"year" db:"year"`
+	Month         string    `json:"month" db:"month_name"`
 	SnapCreatedAt time.Time `json:"snap_created_at" db:"created_at"`
 }
 
-// BudgetLineWithActual combines budget line data with its actual spending and category details.
 type BudgetLineWithActual struct {
-	ID             int64   `json:"id" db:"id"`                           // BudgetLine ID
+	ID             int64   `json:"id" db:"id"`
 	MonthID        int64   `json:"month_id" db:"month_id"`
 	CategoryID     int64   `json:"category_id" db:"category_id"`
 	CategoryName   string  `json:"category_name" db:"category_name"`
 	CategoryColor  string  `json:"category_color" db:"category_color"`
 	Label          string  `json:"label" db:"label"`
-	ExpectedAmount float64 `json:"expected_amount" db:"expected_amount"` // from budget_lines.expected
-	ActualAmount   float64 `json:"actual_amount" db:"actual_amount"`     // from actual_lines.actual
+	ExpectedAmount float64 `json:"expected_amount" db:"expected_amount"`
+	ActualAmount   float64 `json:"actual_amount" db:"actual_amount"`
 }
 
-// BoardDataPayload is the structure returned by the GetBoardData store method.
 type BoardDataPayload struct {
 	MonthID     int64                  `json:"month_id"`
 	Year        int                    `json:"year"`
-	MonthName   string                 `json:"month_name"` // e.g., "January"
+	MonthName   string                 `json:"month_name"`
 	BudgetLines []BudgetLineWithActual `json:"budget_lines"`
-	// Categories  []Category             `json:"categories"` // Optional: if needed separately on the board
 }

--- a/internal/store/month_store.go
+++ b/internal/store/month_store.go
@@ -4,39 +4,19 @@ import (
 	"database/sql" // Used by sqlx, good to have explicitly if direct use is ever needed.
 	"fmt"
 	"time"
-	// sqlx is implicitly used via s.DB, which is *sqlx.DB
-	// "github.com/jmoiron/sqlx"
 )
 
-// CanFinalizeMonth checks if a month can be finalized.
-// A month can be finalized if all its budget lines have a non-zero actual amount.
-// Note: The PRD says "all budget lines have an actual amount" which implies actual_id IS NOT NULL.
-// The provided query checks `al.actual = 0`. This means an actual_line record exists, but its value is 0.
-// If the intent is that *every* budget line *must* have an actual that is *not* zero, the query is correct.
-// If the intent is that *every* budget line *must* have an associated actual_line (even if its value is 0),
-// then the query might need adjustment (e.g., checking for budget_lines without a corresponding actual_line).
-// Given the PRD's "If any budget lines have an actual amount of 0, the month cannot be finalized", the current query seems correct.
 func (s *sqlStore) CanFinalizeMonth(monthID int) (bool, string, error) {
 	var count int
-	// This query identifies budget lines for the given month that are linked to an actual_line
-	// where the actual amount is zero.
 	query := `
 	SELECT COUNT(bl.id)
 	FROM budget_lines bl
 	INNER JOIN actual_lines al ON bl.id = al.budget_line_id 
 	WHERE bl.month_id = ? AND al.actual = 0;
 	`
-	// If there are budget lines that *do not have* an actual_lines record yet,
-	// they would not be caught by this query. The PRD implies an actual_line record
-	// is created when a budget_line is created, possibly with a default of 0.
-	// Assuming actual_lines are always present for budget_lines in a month being considered for finalization.
 
 	err := s.DB.Get(&count, query, monthID)
 	if err != nil {
-		// If no rows are found (e.g. monthID doesn't exist, or no budget lines with actual=0),
-		// sql.ErrNoRows might be returned by s.DB.Get if it expects exactly one row.
-		// However, COUNT should always return one row (with count 0 if no matches).
-		// So, any error here is likely a real issue.
 		return false, "", fmt.Errorf("error checking finalization status for month %d: %w", monthID, err)
 	}
 
@@ -46,15 +26,11 @@ func (s *sqlStore) CanFinalizeMonth(monthID int) (bool, string, error) {
 	return true, "", nil
 }
 
-// FinalizeMonth finalizes a given month and prepares the next month.
-// It creates an annual snapshot, marks the month as finalized,
-// creates the next month's record, and clones budget lines.
 func (s *sqlStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 	tx, err := s.DB.Beginx()
 	if err != nil {
 		return 0, fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	// Using a labeled defer for explicit rollback or commit checking
 	var committed bool = false
 	defer func() {
 		if !committed {
@@ -62,9 +38,7 @@ func (s *sqlStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 		}
 	}()
 
-	// 1. Create Annual Snap
-	// Assuming 'Month' struct and 'BudgetLine' struct are defined in models.go in the same package.
-	createdAt := time.Now().Format("2006-01-02 15:04:05") // Standard SQL datetime format
+	createdAt := time.Now().Format("2006-01-02 15:04:05")
 	_, err = tx.Exec(`
 		INSERT INTO annual_snaps (month_id, snap_json, created_at)
 		VALUES (?, ?, ?);`, monthID, snapJSON, createdAt)
@@ -72,15 +46,12 @@ func (s *sqlStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 		return 0, fmt.Errorf("failed to create annual snap for month %d: %w", monthID, err)
 	}
 
-	// 2. Mark current month as finalized
-	// Assuming 'months' table has 'id' and 'finalized' columns.
 	_, err = tx.Exec(`UPDATE months SET finalized = 1 WHERE id = ?;`, monthID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to mark month %d as finalized: %w", monthID, err)
 	}
 
-	// 3. Determine next month's year and month value
-	var currentMonth Month // This is store.Month from models.go
+	var currentMonth Month
 	err = tx.Get(&currentMonth, `SELECT id, year, month, finalized FROM months WHERE id = ?;`, monthID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get current month details for month %d: %w", monthID, err)
@@ -92,13 +63,10 @@ func (s *sqlStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 		nextYear++
 	}
 
-	// 4. Create new month record for next month
-	// Assuming 'months' table has 'year', 'month', 'finalized' columns.
 	res, err := tx.Exec(`
 		INSERT INTO months (year, month, finalized)
 		VALUES (?, ?, 0);`, nextYear, nextMonthVal)
 	if err != nil {
-		// This could fail due to UNIQUE constraint on (year, month) if it exists and next month already exists.
 		return 0, fmt.Errorf("failed to create next month record for %d-%d: %w", nextYear, nextMonthVal, err)
 	}
 	newMonthID, err := res.LastInsertId()
@@ -106,26 +74,18 @@ func (s *sqlStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 		return 0, fmt.Errorf("failed to get ID of new month (%d-%d): %w", nextYear, nextMonthVal, err)
 	}
 
-	// 5. Get budget lines from current month
-	var budgetLines []BudgetLine // This is store.BudgetLine from models.go
-	// Selecting only fields needed for cloning.
-	// The BudgetLine struct in models.go has ID, MonthID, CategoryID, Label, Expected, ActualID, ActualAmount.
-	// We only need CategoryID, Label, Expected for cloning the line itself.
+	var budgetLines []BudgetLine
 	err = tx.Select(&budgetLines, `
 		SELECT category_id, label, expected 
-		FROM budget_lines WHERE month_id = ?;`, monthID) // Removed bl.id as it's not used for insertion
+		FROM budget_lines WHERE month_id = ?;`, monthID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			// No budget lines to clone, which is a valid scenario.
-			// The rest of the loop will be skipped.
 		} else {
 			return 0, fmt.Errorf("failed to fetch budget lines for month %d: %w", monthID, err)
 		}
 	}
 	
-	// 6. Clone budget lines and create new actual lines for the new month
 	for _, bl := range budgetLines {
-		// The BudgetLine struct has CategoryID, Label, Expected.
 		clonedLineRes, err := tx.Exec(`
 			INSERT INTO budget_lines (month_id, category_id, label, expected)
 			VALUES (?, ?, ?, ?);`, newMonthID, bl.CategoryID, bl.Label, bl.Expected)
@@ -137,7 +97,6 @@ func (s *sqlStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 			return 0, fmt.Errorf("failed to get ID of cloned budget line (label: %s) for new month %d: %w", bl.Label, newMonthID, err)
 		}
 
-		// Create a corresponding actual_lines record with actual = 0
 		_, err = tx.Exec(`
 			INSERT INTO actual_lines (budget_line_id, actual)
 			VALUES (?, 0);`, newBudgetLineID)
@@ -149,6 +108,6 @@ func (s *sqlStore) FinalizeMonth(monthID int, snapJSON string) (int64, error) {
 	if err = tx.Commit(); err != nil {
 		return 0, fmt.Errorf("failed to commit transaction for finalizing month %d and creating month %d: %w", monthID, newMonthID, err)
 	}
-	committed = true // Mark as committed
+	committed = true
 	return newMonthID, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,11 +9,9 @@ import (
 	"strings"
 
 	"github.com/jmoiron/sqlx"
-	_ "github.com/mattn/go-sqlite3" // SQLite driver
+	_ "github.com/mattn/go-sqlite3"
 )
 
-// NewStore initializes and returns a new sqlx.DB connection.
-// It also ensures the database file exists or creates it.
 func NewStore(dataSourceName string) (*sqlx.DB, error) {
 	db, err := sqlx.Connect("sqlite3", dataSourceName)
 	if err != nil {
@@ -23,17 +21,13 @@ func NewStore(dataSourceName string) (*sqlx.DB, error) {
 	return db, nil
 }
 
-// Store defines the interface for database operations.
-// It will include methods for categories, budget lines, and actuals.
 type Store interface {
-	// Category methods
 	GetAllCategories() ([]Category, error)
 	CreateCategory(category *Category) error
 	GetCategoryByID(id int64) (*Category, error)
 	UpdateCategory(category *Category) error
 	DeleteCategory(id int64) error
 
-	// BudgetLine and ActualLine methods
 	CreateBudgetLine(b *BudgetLine) (int64, error)
 	GetBudgetLinesByMonthID(monthID int) ([]BudgetLine, error)
 	UpdateBudgetLine(b *BudgetLine) error
@@ -42,36 +36,27 @@ type Store interface {
 	GetActualLineByID(id int64) (*ActualLine, error)
 	GetBudgetLineByID(id int64) (*BudgetLine, error)
 
-	// Board data methods
-	GetBoardData(monthID int) (*BoardDataPayload, error) // Signature updated
+	GetBoardData(monthID int) (*BoardDataPayload, error)
 
-	// Month finalization methods
-	CanFinalizeMonth(monthID int) (bool, string, error)        // Returns can_finalize, reason, error
-	FinalizeMonth(monthID int, snapJSON string) (int64, error) // Returns new_month_id, error
+	CanFinalizeMonth(monthID int) (bool, string, error)
+	FinalizeMonth(monthID int, snapJSON string) (int64, error)
 
-	// Report methods
 	GetAnnualSnapshotsMetadataByYear(year int) ([]AnnualSnapMeta, error)
 	GetAnnualSnapshotJSONByID(snapID int64) (string, error)
 }
 
-// sqlStore provides a concrete implementation of the Store interface
-// using an sqlx.DB database connection.
 type sqlStore struct {
 	DB *sqlx.DB
 }
 
 func (s *sqlStore) GetAnnualSnapshotsMetadataByYear(year int) ([]AnnualSnapMeta, error) {
-	//TODO implement me
 	panic("implement me")
 }
 
-// NewSQLStore creates a new sqlStore with the given database connection.
 func NewSQLStore(db *sqlx.DB) Store {
 	return &sqlStore{DB: db}
 }
 
-// RunMigrations reads all *.sql files from the specified directory and executes them.
-// It attempts to make migrations idempotent by checking for "table already exists" errors.
 func RunMigrations(db *sqlx.DB, migrationsDir string) error {
 	log.Printf("Looking for migrations in: %s", migrationsDir)
 	files, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
@@ -93,12 +78,9 @@ func RunMigrations(db *sqlx.DB, migrationsDir string) error {
 		query := string(queryBytes)
 		_, err = db.Exec(query)
 		if err != nil {
-			// Basic idempotency check for table creation.
-			// SQLite error message for "table already exists" can vary.
-			// This checks for a common substring.
 			if strings.Contains(err.Error(), "already exists") {
 				log.Printf("Table in migration %s likely already exists, skipping: %v", file, err)
-				continue // Skip this migration file
+				continue
 			}
 			return fmt.Errorf("failed to execute migration file %s: %w", file, err)
 		}
@@ -108,14 +90,13 @@ func RunMigrations(db *sqlx.DB, migrationsDir string) error {
 	return nil
 }
 
-// GetAnnualSnapshotJSONByID retrieves the raw JSON data for a specific annual snapshot by its ID.
 func (s *sqlStore) GetAnnualSnapshotJSONByID(snapID int64) (string, error) {
 	var snapJSON string
 	query := `SELECT snap_json FROM annual_snaps WHERE id = ?;`
 	err := s.DB.Get(&snapJSON, query, snapID)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return "", sql.ErrNoRows // Explicitly return sql.ErrNoRows for the handler to check
+			return "", sql.ErrNoRows
 		}
 		return "", fmt.Errorf("error fetching annual snapshot JSON for ID %d: %w", snapID, err)
 	}

--- a/internal/store/store_test_setup_test.go
+++ b/internal/store/store_test_setup_test.go
@@ -7,34 +7,22 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
-	_ "github.com/mattn/go-sqlite3" // SQLite driver for tests
+	_ "github.com/mattn/go-sqlite3"
 )
 
-// newTestDB sets up an in-memory SQLite database and applies migrations.
 func newTestDB(t *testing.T) *sqlx.DB {
-	t.Helper() // Marks this function as a test helper
+	t.Helper()
 
-	// Use in-memory SQLite database for tests
-	// DSN options like "?_foreign_keys=on" can be added if needed by schema/tests
 	db, err := sqlx.Connect("sqlite3", ":memory:?_foreign_keys=on")
 	if err != nil {
 		t.Fatalf("Failed to connect to in-memory sqlite3: %v", err)
 	}
 
-	// Read the migration file
-	// Assuming the test is run from a context where relative paths to project root are stable.
-	// Adjust path if tests are run from within the package dir or project root.
-	// The path should be relative to the project root.
 	migrationPath := filepath.Join("..", "..", "internal", "store", "migrations", "001_init.sql")
 	
-	// For robustness, try to find the project root if possible, or rely on standard Go test execution paths.
-	// This simplified path assumes `go test ./internal/store/...` is run from project root,
-	// or that the working directory is set up appropriately.
-
 	queryBytes, err := os.ReadFile(migrationPath)
 	if err != nil {
-		// Attempt an alternative path if the first one fails (e.g. if test is run from within package)
-		altMigrationPath := filepath.Join("migrations", "001_init.sql") // common if test is run from `internal/store`
+		altMigrationPath := filepath.Join("migrations", "001_init.sql")
 		queryBytes, err = os.ReadFile(altMigrationPath)
 		if err != nil {
 			t.Fatalf("Failed to read migration file from %s or %s: %v", migrationPath, altMigrationPath, err)
@@ -47,7 +35,6 @@ func newTestDB(t *testing.T) *sqlx.DB {
 		t.Fatalf("Failed to execute migration: %v", err)
 	}
 
-	// Add a cleanup function to close the database connection when the test completes
 	t.Cleanup(func() {
 		err := db.Close()
 		if err != nil {
@@ -58,7 +45,6 @@ func newTestDB(t *testing.T) *sqlx.DB {
 	return db
 }
 
-// Helper to create a category for testing budget lines etc.
 func createTestCategory(t *testing.T, db *sqlx.DB, name string, color string) int64 {
 	t.Helper()
 	res, err := db.Exec("INSERT INTO categories (name, color) VALUES (?, ?)", name, color)
@@ -72,7 +58,6 @@ func createTestCategory(t *testing.T, db *sqlx.DB, name string, color string) in
 	return id
 }
 
-// Helper to create a month record for testing
 func createTestMonth(t *testing.T, db *sqlx.DB, year int, month int, finalized bool) int64 {
 	t.Helper()
 	finalizedInt := 0
@@ -90,7 +75,6 @@ func createTestMonth(t *testing.T, db *sqlx.DB, year int, month int, finalized b
 	return id
 }
 
-// Helper to create a budget line for testing
 func createTestBudgetLine(t *testing.T, db *sqlx.DB, monthID int64, categoryID int64, label string, expected float64) int64 {
 	t.Helper()
 	res, err := db.Exec("INSERT INTO budget_lines (month_id, category_id, label, expected) VALUES (?, ?, ?, ?)",
@@ -105,7 +89,6 @@ func createTestBudgetLine(t *testing.T, db *sqlx.DB, monthID int64, categoryID i
 	return id
 }
 
-// Helper to create an actual line for testing
 func createTestActualLine(t *testing.T, db *sqlx.DB, budgetLineID int64, actual float64) int64 {
 	t.Helper()
 	res, err := db.Exec("INSERT INTO actual_lines (budget_line_id, actual) VALUES (?, ?)", budgetLineID, actual)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,8 +8,12 @@
       "name": "gandalf-budget-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.511.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^7.6.1",
+        "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",
@@ -1377,6 +1381,14 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1406,6 +1418,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2200,6 +2220,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.511.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
+      "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2493,6 +2521,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.1.tgz",
+      "integrity": "sha512-hPJXXxHJZEsPFNVbtATH7+MMX43UDeOauz+EAU4cgqTn7ojdI9qQORqS8Z0qmDlL1TclO/6jLRYUEtbWidtdHQ==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.1.tgz",
+      "integrity": "sha512-vxU7ei//UfPYQ3iZvHuO1D/5fX3/JOqhNTbRR+WjSBWxf9bIvpWK+ftjmdfJHzPOuMQKe2fiEdG+dZX6E8uUpA==",
+      "dependencies": {
+        "react-router": "7.6.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2587,6 +2651,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2660,6 +2729,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/text-table": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,8 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.511.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^7.6.1",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,16 +1,9 @@
-import Dashboard from './pages/Dashboard'; // Default page
-// import Board from './pages/Board';
-// import Report from './pages/Report';
-// import Manage from './pages/Manage';
-// import Backup from './pages/Backup';
+import Dashboard from './pages/Dashboard';
 
 function App() {
   return (
     <div>
-      {/* Basic router placeholder, will be replaced by a proper router later */}
       <Dashboard />
-      {/* Example of how other pages might be switched in later: */}
-      {/* <Board /> */}
     </div>
   );
 }

--- a/web/src/components/CategoryBadge.tsx
+++ b/web/src/components/CategoryBadge.tsx
@@ -10,7 +10,7 @@ interface CategoryBadgeProps {
   className?: string;
 }
 
-const defaultColor = 'bg-gray-500'; // Default color if category or its color is undefined
+const defaultColor = 'bg-gray-500';
 
 export const CategoryBadge: React.FC<CategoryBadgeProps> = ({ category, className = '' }) => {
   const categoryName = category?.name || 'Unknown Category';

--- a/web/src/components/ui/Alert.tsx
+++ b/web/src/components/ui/Alert.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+// Placeholder components to resolve import errors
+export const Alert: React.FC<any> = ({ children, ...props }) => <div {...props}>{children}</div>;
+export const AlertDescription: React.FC<any> = ({ children, ...props }) => <p {...props}>{children}</p>;
+export const AlertTitle: React.FC<any> = ({ children, ...props }) => <h5 {...props}>{children}</h5>;
+
+export default Alert;

--- a/web/src/components/ui/Badge.tsx
+++ b/web/src/components/ui/Badge.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// Placeholder component to resolve import errors
+export const Badge: React.FC<any> = ({ children, ...props }) => <span {...props}>{children}</span>;
+
+export default Badge;

--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -1,18 +1,43 @@
 import React from 'react';
-import { cardClasses } from '../../styles/commonClasses';
+import { cardClasses } from '../../styles/commonClasses'; // Assuming this path is correct and file exists
 
-interface CardProps {
+interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   className?: string;
 }
 
-export const Card: React.FC<CardProps> = ({ children, className }) => {
+export const Card: React.FC<CardProps> = ({ children, className, ...props }) => {
   const combinedClasses = `${cardClasses} ${className || ''}`.trim();
   return (
-    <div className={combinedClasses}>
+    <div className={combinedClasses} {...props}>
       {children}
     </div>
   );
 };
+
+// Placeholder exports for Card sub-components
+export const CardHeader: React.FC<CardProps> = ({ children, className, ...props }) => (
+  <div className={`card-header ${className || ''}`.trim()} {...props}>
+    {children}
+  </div>
+);
+
+export const CardTitle: React.FC<CardProps> = ({ children, className, ...props }) => (
+  <h3 className={`card-title ${className || ''}`.trim()} {...props}>
+    {children}
+  </h3>
+);
+
+export const CardDescription: React.FC<CardProps> = ({ children, className, ...props }) => (
+  <p className={`card-description ${className || ''}`.trim()} {...props}>
+    {children}
+  </p>
+);
+
+export const CardContent: React.FC<CardProps> = ({ children, className, ...props }) => (
+  <div className={`card-content ${className || ''}`.trim()} {...props}>
+    {children}
+  </div>
+);
 
 export default Card;

--- a/web/src/components/ui/Table.tsx
+++ b/web/src/components/ui/Table.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+// Placeholder components to resolve import errors
+export const Table: React.FC<any> = ({ children, ...props }) => <table {...props}>{children}</table>;
+export const TableBody: React.FC<any> = ({ children, ...props }) => <tbody {...props}>{children}</tbody>;
+export const TableCell: React.FC<any> = ({ children, ...props }) => <td {...props}>{children}</td>;
+export const TableHead: React.FC<any> = ({ children, ...props }) => <th {...props}>{children}</th>;
+export const TableHeader: React.FC<any> = ({ children, ...props }) => <thead {...props}>{children}</thead>;
+export const TableRow: React.FC<any> = ({ children, ...props }) => <tr {...props}>{children}</tr>;
+
+export default Table;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2,39 +2,32 @@ const API_BASE_URL = '/api/v1';
 
 interface ApiErrorResponse {
   error: string;
-  details?: any; // Or a more specific error details type
+  details?: any;
 }
 
-// Helper function to handle responses
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
     let errorData: ApiErrorResponse = { error: `HTTP error! status: ${response.status}` };
     try {
-      // Try to parse a JSON error response from the backend
       const parsedError = await response.json();
       if (parsedError && parsedError.error) {
         errorData = parsedError as ApiErrorResponse;
       }
     } catch (e) {
-      // Could not parse JSON error, stick with the HTTP status
       console.error("Could not parse error response as JSON:", e);
     }
     console.error('API call failed:', errorData);
-    throw new Error(errorData.error); // Throw an error that can be caught by the caller
+    throw new Error(errorData.error);
   }
-  // If response is OK, try to parse JSON, but handle cases with no content (e.g., 204)
   const contentType = response.headers.get("content-type");
   if (contentType && contentType.indexOf("application/json") !== -1) {
     return response.json() as Promise<T>;
-  } else if (response.status === 204) { // No Content
-    return Promise.resolve(null as T); // Or undefined, depending on how you want to handle it
+  } else if (response.status === 204) {
+    return Promise.resolve(null as T);
   }
-  // For non-JSON responses, you might want to return text or blob
-  // For now, we'll assume JSON or no content for successful responses
-  return response.text() as Promise<any>; // Fallback for unexpected content types
+  return response.text() as Promise<any>;
 }
 
-// GET request helper
 export async function get<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: 'GET',
@@ -46,7 +39,6 @@ export async function get<T>(path: string): Promise<T> {
   return handleResponse<T>(response);
 }
 
-// POST request helper
 export async function post<T, U>(path: string, body: U): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: 'POST',
@@ -59,7 +51,6 @@ export async function post<T, U>(path: string, body: U): Promise<T> {
   return handleResponse<T>(response);
 }
 
-// PUT request helper
 export async function put<T, U>(path: string, body: U): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: 'PUT',
@@ -72,55 +63,26 @@ export async function put<T, U>(path: string, body: U): Promise<T> {
   return handleResponse<T>(response);
 }
 
-// DELETE request helper
-export async function del<T>(path: string): Promise<T> { // 'delete' is a reserved keyword
+export async function del<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: 'DELETE',
     headers: {
-      'Accept': 'application/json', // Expect JSON error response, but 204 on success
+      'Accept': 'application/json',
     },
   });
-  return handleResponse<T>(response); // Will handle 204 No Content correctly
+  return handleResponse<T>(response);
 }
 
-// Example usage (optional, for testing or demonstration):
-/*
-interface Category {
-  id: number;
-  name: string;
-  color: string;
-}
-
-async function testApi() {
-  try {
-    const categories = await get<Category[]>('/categories');
-    console.log('Categories:', categories);
-
-    if (categories.length > 0) {
-      const firstCatId = categories[0].id;
-      const updatedCat = await put<Category, Partial<Category>>(`/categories/${firstCatId}`, { name: 'Updated Name' });
-      console.log('Updated Category:', updatedCat);
-    }
-
-  } catch (error) {
-    console.error('Error in testApi:', error);
-  }
-}
-// testApi();
-*/
-
-// TypeScript types for BudgetLine and ActualLine
 export interface BudgetLine {
   id: number;
   month_id: number;
   category_id: number;
   label: string;
   expected: number;
-  // Optional fields if your API might join them, or if you plan to merge client-side
-  category_name?: string; 
+  category_name?: string;
   category_color?: string;
-  actual_amount?: number; // To store the actual amount from ActualLine
-  actual_id?: number; // ID of the associated ActualLine record
+  actual_amount?: number;
+  actual_id?: number;
 }
 
 export interface ActualLine {
@@ -143,15 +105,13 @@ export async function updateBudgetLine(id: number, data: { label?: string; expec
 }
 
 export async function deleteBudgetLine(id: number): Promise<void> {
-  return del<void>(`/budget-lines/${id}`); // Expects 204 No Content, handleResponse handles this
+  return del<void>(`/budget-lines/${id}`);
 }
 
-// API function for Actual Lines
 export async function updateActualLine(id: number, data: { actual: number }): Promise<ActualLine> {
   return put<ActualLine, typeof data>(`/actual-lines/${id}`, data);
 }
 
-// --- Board Data API (Updated) ---
 export interface BudgetLineWithActual {
   id: number;
   month_id: number;
@@ -168,29 +128,21 @@ export interface BoardDataPayload {
   year: number;
   month_name: string;
   budget_lines: BudgetLineWithActual[];
-  // categories?: Category[]; // This was optional, not adding for now as backend doesn't include it here
 }
 
-// API function for Board Data (Updated)
 export async function getBoardData(monthId: string | number): Promise<BoardDataPayload> {
-  // The PRD endpoint for board data is /board/:monthId, but current implementation uses /board-data/:monthId
-  // Assuming /board-data/:monthId is correct as per existing code.
-  // If it should be /api/v1/board/:monthId, this path needs to be changed.
-  // Sticking to /board-data/ for now.
   return get<BoardDataPayload>(`/board-data/${monthId}`);
 }
 
-// API function for Finalizing Month
 interface FinalizeMonthResponse {
-  message: string; // e.g., "Month finalized successfully"
+  message: string;
   new_month_id: number;
 }
 
 export async function finalizeMonth(monthId: string | number): Promise<FinalizeMonthResponse> {
-  return put<FinalizeMonthResponse, null>(`/months/${monthId}/finalize`, null); // No body for this PUT request
+  return put<FinalizeMonthResponse, null>(`/months/${monthId}/finalize`, null);
 }
 
-// --- Existing Category types and functions for context ---
 export interface Category {
   id: number;
   name: string;
@@ -213,10 +165,8 @@ export async function deleteCategory(id: number): Promise<void> {
   return del<void>(`/categories/${id}`);
 }
 
-// --- Dashboard API ---
-
 export interface BudgetLineDetail {
-  budget_line_id: number; // Note: Go uses `json:"budget_line_id"` which becomes budget_line_id
+  budget_line_id: number;
   label: string;
   expected_amount: number;
   actual_amount: number;
@@ -247,22 +197,18 @@ export async function getDashboardData(monthId: number | string): Promise<Dashbo
   return get<DashboardPayload>(`/dashboard?month_id=${monthId}`);
 }
 
-// --- Reports API ---
-
 export interface AnnualSnapMeta {
-  id: number; // Changed from int64 in Go to number in TS
-  month_id: number; // Changed from int64 in Go to number in TS
+  id: number;
+  month_id: number;
   year: number;
-  month: string; 
-  snap_created_at: string; // ISO date string (Go's time.Time marshals to this format)
+  month: string;
+  snap_created_at: string;
 }
 
 export async function getAnnualSnapshots(year: number): Promise<AnnualSnapMeta[]> {
   return get<AnnualSnapMeta[]>(`/reports/annual?year=${year}`);
 }
 
-// The backend GetSnapshotDetail returns the raw JSON string of DashboardPayload.
-// The `get` helper in api.ts already handles response.json(), so it should correctly parse this.
 export async function getSnapshotDetail(snapId: number): Promise<DashboardPayload> {
   return get<DashboardPayload>(`/reports/snapshots/${snapId}`);
 }

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -5,7 +5,6 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
-// Helper to format currency
 export const formatCurrency = (amount: number | null | undefined) => {
   if (amount === null || amount === undefined) {
     return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(0);

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-// import './index.css'; // Optional: if you add global styles
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/web/src/pages/Board.tsx
+++ b/web/src/pages/Board.tsx
@@ -10,13 +10,12 @@ import CategoryBadge from '../components/CategoryBadge';
 
 export default function BoardPage() {
   const [boardData, setBoardData] = useState<api.BoardDataPayload | null>(null);
-  const [currentMonthId, setCurrentMonthId] = useState<number>(1); // Default to month 1, or load from URL param
+  const [currentMonthId, setCurrentMonthId] = useState<number>(1);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isFinalizing, setIsFinalizing] = useState(false);
   const [finalizeMessage, setFinalizeMessage] = useState<string | null>(null);
 
-  // Fetch board data
   const fetchBoardData = async (monthId: number) => {
     setIsLoading(true);
     setError(null);
@@ -47,8 +46,7 @@ export default function BoardPage() {
     try {
       const response = await api.finalizeMonth(currentMonthId);
       setFinalizeMessage(response.message || "Month finalized successfully!");
-      // After finalizing, fetch data for the new month and update currentMonthId
-      setCurrentMonthId(response.new_month_id); // This will trigger useEffect to reload board data
+      setCurrentMonthId(response.new_month_id);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "Failed to finalize month. Check if all actuals are set or an error occurred.";
       setError(errorMessage);
@@ -58,18 +56,16 @@ export default function BoardPage() {
   };
 
   const handleActualAmountChange = async (
-    budgetLineId: number, // This is BudgetLineWithActual.id
+    budgetLineId: number,
     newActualString: string
   ) => {
     const newActual = parseFloat(newActualString);
     if (isNaN(newActual) || newActual < 0) {
       alert("Please enter a valid positive number for the actual amount.");
-      // Optionally refetch to revert optimistic update, or just reset input visually
-      fetchBoardData(currentMonthId); 
+      fetchBoardData(currentMonthId);
       return;
     }
 
-    // Optimistic UI update
     if (boardData) {
       setBoardData({
         ...boardData,
@@ -80,27 +76,21 @@ export default function BoardPage() {
     }
 
     try {
-      // PRD implies /line/:id uses budget_line_id.
-      // Assuming api.updateActualLine is adapted or a new function api.updateBudgetLineActual is used.
-      // For this task, we'll assume api.updateActualLine takes budgetLineId as its first argument.
-      // This is a key assumption for this refactor to be fully functional.
       await api.updateActualLine(budgetLineId, { actual: newActual });
     } catch (err) {
       alert(`Failed to update actual amount: ${err instanceof Error ? err.message : 'Unknown error'}`);
       setError(err instanceof Error ? `Failed to update: ${err.message}` : 'Failed to update actual amount.');
-      // Revert optimistic update or refetch
-      fetchBoardData(currentMonthId); 
+      fetchBoardData(currentMonthId);
     }
   };
   
   const getRowColor = (line: api.BudgetLineWithActual): string => {
     if (line.actual_amount && Number(line.actual_amount) > 0) {
-      return 'bg-green-700 hover:bg-green-600'; 
+      return 'bg-green-700 hover:bg-green-600';
     }
-    return 'bg-yellow-700 hover:bg-yellow-600'; 
+    return 'bg-yellow-700 hover:bg-yellow-600';
   };
 
-  // Initial loading state
   if (isLoading && !boardData) return <LoadingSpinner text="Loading board data..." />;
 
   return (
@@ -113,7 +103,7 @@ export default function BoardPage() {
         <div className="flex items-center space-x-2">
           <label htmlFor="month_id_selector_board" className="block text-sm font-medium">Select Month ID:</label>
           <Input
-            id="month_id_selector_board" // Corrected ID
+            id="month_id_selector_board"
             type="number"
             value={currentMonthId}
             onChange={(e) => setCurrentMonthId(parseInt(e.target.value, 10) || 1)}
@@ -125,8 +115,7 @@ export default function BoardPage() {
           <Button
             onClick={handleFinalizeMonth}
             disabled={isFinalizing || isLoading || boardLines.length === 0}
-            className="text-sm bg-green-600 hover:bg-green-700" 
-            // disabled:bg-gray-500 disabled:cursor-not-allowed is handled by disabledClasses in Button
+            className="text-sm bg-green-600 hover:bg-green-700"
           >
             {isFinalizing ? 'Finalizing...' : 'Finalize Current Month'}
           </Button>
@@ -171,7 +160,7 @@ export default function BoardPage() {
                       onBlur={(e: ChangeEvent<HTMLInputElement>) => 
                         handleActualAmountChange(line.id, line.actual_id, e.target.value)
                       }
-                      className="!text-black w-full text-sm" // Ensure text is visible, take full cell width
+                      className="!text-black w-full text-sm"
                       placeholder="0"
                       min="0"
                       step="1"

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { getDashboardData, DashboardPayload, CategorySummary, BudgetLineDetail } from '../lib/api'; // Ensure snake_case interfaces are exported from api.ts
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table';
-import { Badge } from '../components/ui/badge'; // For general purpose badges if needed
-import { CategoryBadge } from '../components/CategoryBadge'; // Assuming this component exists and works as described
-import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
+import { getDashboardData, DashboardPayload, CategorySummary, BudgetLineDetail } from '../lib/api';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../components/ui/Card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/Table';
+import { Badge } from '../components/ui/Badge';
+import { CategoryBadge } from '../components/CategoryBadge';
+import { Alert, AlertDescription, AlertTitle } from '../components/ui/Alert';
 import { Loader2 } from 'lucide-react';
-import { formatCurrency } from '../lib/utils'; // Updated import
+import { formatCurrency } from '../lib/utils';
 
 export default function Dashboard() {
   const [searchParams] = useSearchParams();

--- a/web/src/pages/Report.tsx
+++ b/web/src/pages/Report.tsx
@@ -6,13 +6,11 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../co
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../components/ui/table';
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
 import { Loader2 } from 'lucide-react';
-import ReadOnlyDashboardView from '../components/ReadOnlyDashboardView'; // Added import
+import ReadOnlyDashboardView from '../components/ReadOnlyDashboardView';
 
-// Helper to format date strings
 const formatDate = (dateString: string) => {
   if (!dateString) return 'N/A';
   try {
-    // Attempt to handle both ISO string with Z and without
     const date = new Date(dateString.endsWith('Z') ? dateString : dateString + 'Z');
     return date.toLocaleDateString('en-US', {
       year: 'numeric',
@@ -20,11 +18,11 @@ const formatDate = (dateString: string) => {
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
-      timeZone: 'UTC' // Assuming created_at is UTC, display as such or convert to local
+      timeZone: 'UTC'
     });
   } catch (e) {
     console.warn("Failed to parse date:", dateString, e);
-    return dateString; // Fallback if parsing fails
+    return dateString;
   }
 };
 
@@ -50,7 +48,7 @@ export default function ReportPage() {
     setSnapshots([]);
 
     const yearNum = parseInt(yearInput, 10);
-    if (isNaN(yearNum) || yearInput.length !== 4) { // Basic year format validation
+    if (isNaN(yearNum) || yearInput.length !== 4) {
       setErrorSnapshots("Please enter a valid four-digit year.");
       return;
     }
@@ -72,7 +70,7 @@ export default function ReportPage() {
 
   const handleViewSnapshot = async (snapId: number) => {
     setSelectedSnapId(snapId);
-    setSnapshotDetail(null); // Clear previous detail
+    setSnapshotDetail(null);
     setErrorDetail(null);
     setLoadingDetail(true);
     try {
@@ -101,8 +99,8 @@ export default function ReportPage() {
               value={yearInput}
               onChange={(e) => setYearInput(e.target.value)}
               className="max-w-xs"
-              min="2000" // Reasonable min year
-              max="2099" // Reasonable max year
+              min="2000"
+              max="2099"
             />
             <Button onClick={handleLoadReports} disabled={loadingSnapshots}>
               {loadingSnapshots && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
@@ -187,8 +185,6 @@ export default function ReportPage() {
       {snapshotDetail && !loadingDetail && (
         <Card className="mt-6">
           <CardHeader>
-            {/* Title is now part of ReadOnlyDashboardView, but we can keep a general title here or remove */}
-            {/* <CardTitle>Snapshot Detail: {snapshotDetail.month} {snapshotDetail.year}</CardTitle> */}
              <CardDescription>
               Displaying the content of the selected snapshot.
             </CardDescription>

--- a/web/src/styles/commonClasses.ts
+++ b/web/src/styles/commonClasses.ts
@@ -1,8 +1,7 @@
-// Basic Tailwind classes - can be expanded
 export const inputClasses = "border border-gray-300 rounded px-2 py-1 text-black";
 export const buttonClasses = "bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-2 rounded";
 export const destructiveButtonClasses = "bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded";
 export const secondaryButtonClasses = "bg-gray-500 hover:bg-gray-600 text-white font-bold py-1 px-2 rounded";
-export const cardClasses = "bg-gray-800 p-4 rounded shadow-md mb-4"; // Changed to dark theme card
-export const textMutedClasses = "text-gray-400"; // For placeholder text or muted info
+export const cardClasses = "bg-gray-800 p-4 rounded shadow-md mb-4";
+export const textMutedClasses = "text-gray-400";
 export const disabledClasses = "opacity-50 cursor-not-allowed";


### PR DESCRIPTION
This commit removes comments from Go and frontend source files to promote self-documenting code.

It also updates PRD_TODO.md with a new coding principle (10.5) discouraging the use of comments when code can be made clearer.

Additionally, this commit includes fixes for the frontend build:
- Installed missing npm dependencies (react-router-dom, lucide-react, etc.)
- Resolved various import errors in .tsx files.
- Added placeholder components for Table, Badge, and Alert to allow the build to pass, as shadcn/ui setup was not feasible immediately.
- Confirmed `npm run build` and `npm run dev` are operational.